### PR TITLE
Add less specific "Container Registry Authentication" rule to address pull secrets with newlines.

### DIFF
--- a/patterns/gitleaks/7.6.1/98-general.toml
+++ b/patterns/gitleaks/7.6.1/98-general.toml
@@ -110,17 +110,32 @@
 
 [[rules]]
   description = "Container Registry Authentication"
+  regex = '''(\\)?\"auth(\\)?\"?(\s+)?:(\s+)?(\\)?\"([^\"]{32,})(\\)?\"'''
+  tags = ["alert:repo-owner", "container-registry", "auth", "type:secret"]
+
+  [[rules.entropies]]
+    Min = "3.2"
+    Max = "8"
+    Group = "6"
+
+  [rules.allowlist]
+    regexes = [
+      '''\"auth(\\)?\"(\s+)?:(\s+)?(\\)?\"([^\"]+(\.\.\.|\*\*\*)[^\"]+)(\\)?\"'''
+    ]
+
+[[rules]]
+  description = "Container Registry Authentication"
   # Works for quay, openshift, redhat, and docker registries
   # Example match: "quay.io": {"auth": "token-token-token-token"
   # It also tries to ignore space around the json
   # (Note: this only works when it's all on a single line)
-  regex = '''(\\)?\"([^\"]+)?(docker|quay|openshift|redhat)\.(io|com)(\\)?\"(\s+)?:(\s+)?\{(\s+)?(\\)?\"auth(\\)?\"(\s+)?:(\s+)?(\\)?\"([^\"]{32,})(\\)?\"'''
+  regex = '''(\\)?\"([^\"]+)?(docker|quay|openshift|openshiftapps|redhat)\.(io|com|org)(\\)?([^\"]+)?"(\s+)?:(\s+)?\{(\s+)?(\\)?\"auth(\\)?\"(\s+)?:(\s+)?(\\)?\"([^\"]{32,})(\\)?\"'''
   tags = ["alert:repo-owner", "type:secret", "container-registry", "auth"]
 
   [[rules.entropies]]
     Min = "3.2"
     Max = "8"
-    Group = "14"
+    Group = "15"
 
   [rules.allowlist]
     regexes = [

--- a/target/patterns/gitleaks/7.6.1
+++ b/target/patterns/gitleaks/7.6.1
@@ -146,17 +146,32 @@
 
 [[rules]]
   description = "Container Registry Authentication"
+  regex = '''(\\)?\"auth(\\)?\"?(\s+)?:(\s+)?(\\)?\"([^\"]{32,})(\\)?\"'''
+  tags = ["alert:repo-owner", "container-registry", "auth", "type:secret"]
+
+  [[rules.entropies]]
+    Min = "3.2"
+    Max = "8"
+    Group = "6"
+
+  [rules.allowlist]
+    regexes = [
+      '''\"auth(\\)?\"(\s+)?:(\s+)?(\\)?\"([^\"]+(\.\.\.|\*\*\*)[^\"]+)(\\)?\"'''
+    ]
+
+[[rules]]
+  description = "Container Registry Authentication"
   # Works for quay, openshift, redhat, and docker registries
   # Example match: "quay.io": {"auth": "token-token-token-token"
   # It also tries to ignore space around the json
   # (Note: this only works when it's all on a single line)
-  regex = '''(\\)?\"([^\"]+)?(docker|quay|openshift|redhat)\.(io|com)(\\)?\"(\s+)?:(\s+)?\{(\s+)?(\\)?\"auth(\\)?\"(\s+)?:(\s+)?(\\)?\"([^\"]{32,})(\\)?\"'''
+  regex = '''(\\)?\"([^\"]+)?(docker|quay|openshift|openshiftapps|redhat)\.(io|com|org)(\\)?([^\"]+)?"(\s+)?:(\s+)?\{(\s+)?(\\)?\"auth(\\)?\"(\s+)?:(\s+)?(\\)?\"([^\"]{32,})(\\)?\"'''
   tags = ["alert:repo-owner", "type:secret", "container-registry", "auth"]
 
   [[rules.entropies]]
     Min = "3.2"
     Max = "8"
-    Group = "14"
+    Group = "15"
 
   [rules.allowlist]
     regexes = [


### PR DESCRIPTION
Gitleaks added multi-line support in version 8.0 and the existing "Container Registry Authentication" rule would require multi-line support to match a non-flat file.

Additionally check more known registry domains and allow for registry URL to contain a repository preceded by a `/` such as `quay.io/specific-repo`.