### PR TITLE
Shorten IDs

### DIFF
--- a/patterns/gitleaks/8.18.2/98-general.toml
+++ b/patterns/gitleaks/8.18.2/98-general.toml
@@ -1,5 +1,5 @@
 [[rules]]
-  id = 'c42a367392fc3aadefbf9caa4de4582a790b8746ed72e6e97fca6f962502597a'
+  id = 'nPY_Rcj4gzY'
   description = 'ArgoCD JWT'
   # Based on shifted b64 encoded portions of '"iss":"argocd"'
   regex = '''[a-zA-Z0-9-_]+\.[a-zA-Z0-9-_]+(?:ImlzcyI6ImFyZ29jZC|Jpc3MiOiJhcmdvY2Qi|iaXNzIjoiYXJnb2NkI)[a-zA-Z0-9-_]+\.[a-zA-Z0-9-_]+'''
@@ -11,7 +11,7 @@
   ]
 
 [[rules]]
-  id = 'ab58b5955845a843962cb6ac631b1d44a0cef6a37e060988e7e58b039706ca51'
+  id = 'LAJoYTdoQH4'
   description = 'AWS IAM Unique Identifier'
   # The funky not group at the beginning consists of ascii ranges
   regex = '''(?:^|[^!$-&\(-9<>-~])((?:A3T[A-Z0-9]|ACCA|ABIA|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16})\b'''
@@ -46,7 +46,7 @@
     ]
 
 [[rules]]
-  id = '308f20b091650166decc757badd05c51384601ac6d10c11d5282c37004fff959'
+  id = '9j_rmwDeioM'
   description = 'AWS Secret Access Key'
   regex = '''(?i)aws[\w\-]{0,32}[\'\"]?\s*?[:=\(]\s*?[\'\"]?([a-z0-9\/+]{40})\b'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -86,7 +86,7 @@
     ]
 
 [[rules]]
-  id = '2eefe8aec9ce2ef59bd4e258d84ed17a0303dee93e6dffb49002acc877d33ee1'
+  id = 'd01DtP9iA8I'
   # Sometimes the values in the config are base64 encoded (e.g. in the case of openshift secrets)
   description = 'Base64 Encoded AWS Secret Access Key'
   regex = '''[a-zA-Z0-9\/\+]*(?:YXdzX2FjY2Vzc19rZXlfaW|F3c19hY2Nlc3Nfa2V5X2lk|hd3NfYWNjZXNzX2tleV9pZ)[a-zA-Z0-9\/\+]*(?:QUtJQ|FLSU|BS0lB|UVV0Sl|FVdEpR|RVXRKU|RkxTV|ZMU1|GTFNV|QlMwbE|JTMGxC|CUzBsQ)[a-zA-Z0-9\/\+]*(?:YXdzX3NlY3JldF9hY2Nlc3Nfa2V5|F3c19zZWNyZXRfYWNjZXNzX2tle|hd3Nfc2VjcmV0X2FjY2Vzc19rZX)[a-zA-Z0-9\/\+]+={0,2}'''
@@ -99,7 +99,7 @@
 
 
 [[rules]]
-  id = '3161082b147ad645b6d3637f68edcfa87949a79b45004efeef036e2cb7a0edfe'
+  id = 'gpfGmO3HH64'
   description = 'Container Registry Authentication'
   regex = '''\\*\"auths\\*\"\s*:\s*\{\s*(?:\\*\"(?:[a-z0-9\-]{1,63}\.)+(?:[a-z0-9\-]{1,63})\\*\"\s*:\s*\{\s*\\*\"auth\\*\"\s*:\s*\\*\"[\w\/+-]{32,}={0,2}\\*\"[\s\S]*?\},?\s*)+\}'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -117,7 +117,7 @@
     ]
 
 [[rules]]
-  id = 'e0e0ef11399b51b8efa864542979614bd1bb2288f3cb8bd2aa786e1a4aee9e79'
+  id = 'me-TlU0uKS8'
   description = 'Dynatrace Token'
   regex = '''\bdt0[a-zA-Z]{1}[0-9]{2}\.[A-Z0-9]{24}\.[A-Z0-9]{64}\b'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -126,7 +126,7 @@
   ]
 
 [[rules]]
-  id = 'fc611155cdab32cb4ac3edf51045a9f73e066eee77c2c8d9771b29e7849212c0'
+  id = 'bzBQF-LMlZU'
   description = 'Facebook Access Token'
   regex = '''\bEAACEdEose0cBA(?i)[a-z0-9]{128,256}\b'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -135,7 +135,7 @@
   ]
 
 [[rules]]
-  id = '13852bbfce4794be0e9740ef28cd7cb9d06776b8d6428e3b4e8350bb03260528'
+  id = 'fdc8WJ7tfUA'
   description = 'Facebook Secret'
   regex = '''(?i)(?:facebook)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{32})(?:[\'\"\s\x60;,]|$)'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -144,7 +144,7 @@
   ]
 
 [[rules]]
-  id = '08147f6d4edc040aa8cc8d9313221aad0f0826de534f250b9987e6357bf8ae44'
+  id = 'mC5kOxQ6kn4'
   description = 'Generic Secret'
   # This one looks for tokens in files with extensions like:
   # - app.clientSecret
@@ -179,7 +179,7 @@
     ]
 
 [[rules]]
-  id = 'cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22'
+  id = '_-9w6-yrc-4'
   description = 'Generic Secret'
   # Things like:
   #   password = "value"
@@ -363,7 +363,7 @@
     ]
 
 [[rules]]
-  id = 'a8d78f8de4bad0b519a8a14b625bc6d8ae3055bd8d8de6fc5c4b0b31bac4249e'
+  id = 'eCOHX_SKGzA'
   description = 'Generic Secret'
   regex = '''(?i)<\s*?\w*?(?:password|secret|token)[\s\w\"\'=]*?>(?:<!\[CDATA\[)?([^\"\s]+?)(?:\]\]>)?<\/(?:[\s\w\"\'=]*?>)?'''
   entropy = 3.5
@@ -443,7 +443,7 @@
     ]
 
 [[rules]]
-  id = 'dd85b788ea6c12f4968c38091c2576ff17ce23565d8d14f2a3b34d44dccddec2'
+  id = 'rnWF160pWNg'
   # Captures things like normal Generic Secret but handles the case where
   # the value in a yaml file is unquoted
   description = 'Generic Secret'
@@ -599,7 +599,7 @@
     ]
 
 [[rules]]
-  id = 'f71af8c158940a1539bfb08feaa24e36bf584c9c819002ea989c6aa35319d2db'
+  id = 'kX_PwM0MFvE'
   description = 'GitHub Fine-Grained Personal Access Token'
   regex = '''\bgithub_pat_\w{82}\b'''
   entropy = 2
@@ -609,7 +609,7 @@
   ]
 
 [[rules]]
-  id = '0e347181fa64a66c62628972058788e0caf23a3c6a5be7822a01f29b65a6a9f0'
+  id = '3J1l0v_MrA0'
   description = 'GitHub OAuth Access Token'
   regex = '''\bgho_[0-9A-Za-z]{36}\b'''
   entropy = 2
@@ -619,7 +619,7 @@
   ]
 
 [[rules]]
-  id = 'a4ec986531bed1c154627c941eda6a95ef016481574cdfcb34249b648eb85ec7'
+  id = 'gODCNuGzuKQ'
   description = 'GitHub Personal Access Token'
   regex = '''\bghp_[0-9A-Za-z]{36}\b'''
   entropy = 2
@@ -629,7 +629,7 @@
   ]
 
 [[rules]]
-  id = '86141b0de6dfc25b4ff6fe7c74c9283367a1d1c9c2d4df99ad9b8948e5d462db'
+  id = 'ReSYq_S3Ou0'
   description = 'GitHub Refresh Token'
   regex = '''\bghr_[0-9A-Za-z]{36}\b'''
   entropy = 2
@@ -639,7 +639,7 @@
   ]
 
 [[rules]]
-  id = '357286368ed645f842a99b4b1bf585181a6edf2e466287fa97fa8e887729e614'
+  id = 'YmXj5Lk-jw4'
   description = 'GitHub Server to Server Token'
   regex = '''\bghs_[0-9A-Za-z]{36}\b'''
   entropy = 2
@@ -649,7 +649,7 @@
   ]
 
 [[rules]]
-  id = 'afe1c727a3b8fb95f9b4e08ff05d501c5faab40e3c621ebc95468bae6dfb7d1b'
+  id = 'MMuUwURWAhM'
   description = 'GitHub User to Server Token'
   regex = '''\bghu_[0-9A-Za-z]{36}\b'''
   entropy = 2
@@ -659,7 +659,7 @@
   ]
 
 [[rules]]
-  id = '0f6a47c693ad7a56c4a835f6aa7b38d18c343becae2f833fac2db51ecebd79e2'
+  id = 'KJX2Vbp6_jY'
   description = 'GitLab Access Token'
   regex = '''\bglpat-[\w\-]{20}\b'''
   entropy = 2
@@ -669,7 +669,7 @@
   ]
 
 [[rules]]
-  id = '798acef3dc3135b6c9482635a042cb405e3c050631ef0e3ccc3556dddc9254d1'
+  id = 'IOimnsNGyvw'
   description = 'GitLab Pipeline Trigger Token'
   regex = '''\bglptt-[0-9a-f]{40}\b'''
   entropy = 2
@@ -679,7 +679,7 @@
   ]
 
 [[rules]]
-  id = '7561d77130281f0e7b2339650a591ca94bf46c41dd9ca8cfe137fd4a1953d1b8'
+  id = '5eH7BIYmpNo'
   description = 'GitLab Runner Registration Token'
   regex = '''\b(?:glrt-|GR1348941)[\w\-]{20}\b'''
   entropy = 2
@@ -690,7 +690,7 @@
   ]
 
 [[rules]]
-  id = '051eedb0bcb561306cadb6f5d310147c71edc1965d29b07ab38df8c54a623aba'
+  id = 'HysINeDft8k'
   description = 'Google Cloud Platform API Key'
   regex = '''\bAIza[0-9A-Za-z\\-_]{35}\b'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -699,7 +699,7 @@
   ]
 
 [[rules]]
-  id = '33dc3d2c2470b17d9a29bd1f66d650f36dfab0e01ada76b8d7e254cd5da93ed9'
+  id = 'F8ySDDFvEPA'
   description = 'Groq API Key'
   regex = '''\bgsk_[A-Za-z0-9]{52}\b'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -710,7 +710,7 @@
   ]
 
 [[rules]]
-  id = '25a1be50e7c5c93b6f7d468adaadd6ff0f62dea6f60af64c9415f5b6ccbee8ce'
+  id = '6Tfk9iWtINY'
   description = 'Heroku API Token'
   regex = '''(?i)heroku(?:.{0,20})?\b([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\b'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -719,7 +719,7 @@
   ]
 
 [[rules]]
-  id = '365926758922192ee27da4b29bc2cb6ee7b3af1bbf75cfd479283b57c909a58f'
+  id = '8nWBN4ZoGf8'
   description = 'Htpasswd File'
   path = '''htpasswd[^\/]*?$'''
   regex = '''[^:\s]{1,255}:(\S{1,255})'''
@@ -738,7 +738,7 @@
     ]
 
 [[rules]]
-  id = '35dfcd9a65eaa32f3ba685014cdfc0963b411b48853263df5a5582bb3620d0fe'
+  id = 'ROB1tToGkqM'
   description = 'Hugging Face API Token'
   regex = '''\bhf_[a-zA-Z]{34}\b'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -747,7 +747,7 @@
   ]
 
 [[rules]]
-  id = '50ed3470a6a293dd257ba4786f2e08da9e6eec64442c606f81859150f29e9b49'
+  id = 'vAAom0bPHy8'
   # base64 shifted versions of '"sub":"system:serviceaccount:'
   description = 'Kubernetes System Service Account JWT'
   regex = '''[a-zA-Z0-9-_]+\.[a-zA-Z0-9-_]+(?:InN1YiI6InN5c3RlbTpzZXJ2aWNlYWNjb3VudD|JzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6|ic3ViIjoic3lzdGVtOnNlcnZpY2VhY2NvdW50O)[a-zA-Z0-9-_]+\.[a-zA-Z0-9-_]+'''
@@ -759,7 +759,7 @@
   ]
 
 [[rules]]
-  id = '0dc120e36dbbe5eec937807366ca120ce22e0ee28543f6e08fcb09039fb1b8dc'
+  id = 'Evwi072oSOU'
   description = 'MailChimp API Key'
   regex = '''\b[0-9a-f]{32}-us[0-9]{1,2}\b'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -768,7 +768,7 @@
   ]
 
 [[rules]]
-  id = '3bbe47102af6d87aaba1814062eae73dc0a840adcec38451a6cb5689d74a6961'
+  id = '0Fj-HDkaBWM'
   description = 'Mailgun API Key'
   regex = '''(?i)(?:mailgun|mg).{0,20}?\b(key-[0-9a-z]{32})\b'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -778,7 +778,7 @@
   ]
 
 [[rules]]
-  id = 'c23ef58e849f9272eddd95bb6f9ea503341d4b7f6f043088b227252e8ebefe8b'
+  id = 'tBcMT24UjGQ'
   description = 'NPM Access Token'
   regex = '''\bnpm_[A-Za-z0-9]{36}\b'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -788,7 +788,7 @@
   ]
 
 [[rules]]
-  id = 'fd46ccfd70fb3b77859e535635c0fe3cb51c7d5be6f23f9cc40c5d0d226f59a1'
+  id = 'tSFtnbvWdlk'
   description = 'NPM Registry Auth'
   regex = '''_(?:auth(?:Token)?|password)\s*=\s*(.+)'''
   path = '''(^|\/)[^\/]+npmrc$'''
@@ -807,7 +807,7 @@
     ]
 
 [[rules]]
-  id = '7c288b0becc8b6186eb504a34fc56ea0102837ee0aaa1e573c4c82fa7aec808c'
+  id = 'DaAdIBwZoGE'
   description = 'OpenShift Login Token'
   regex='''\boc\s+login\s+.*?--token\s*=?\s*(sha256~[^<\s]{16,})\b'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -817,7 +817,7 @@
   ]
 
 [[rules]]
-  id = '0f75ca0dd1fd85ed8160b8a693107cdf3904edf31d0985edf84fabf7500f2c2c'
+  id = 'bYudTkTa56I'
   description = 'Password Hash'
   regex = '''\$y\$[.\/A-Za-z0-9]+\$[.\/A-Za-z0-9]{0,86}\$[.\/A-Za-z0-9]{43}'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -826,7 +826,7 @@
   ]
 
 [[rules]]
-  id = 'd843e3b5ee1a726c2570c8fb14e26509d699d8bb1aa2426b9c5ec6127670abac'
+  id = 'fqtWnpN0lfA'
   description = 'Password Hash'
   regex = '''\$gy\$[.\/A-Za-z0-9]+\$[.\/A-Za-z0-9]{0,86}\$[.\/A-Za-z0-9]{43}'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -835,7 +835,7 @@
   ]
 
 [[rules]]
-  id = 'e1074cf73d2a7d60b233984d261979b5d623277f03d0e334c67a71c99362c6c1'
+  id = 'MxYvbqkT9IM'
   description = 'Password Hash'
   regex = '''\$7\$[.\/A-Za-z0-9]{11,97}\$[.\/A-Za-z0-9]{43}'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -844,7 +844,7 @@
   ]
 
 [[rules]]
-  id = 'a0e89d6e0593122ed5f0fcf19b54f480b63767b925a4c844f1da27dbf5462013'
+  id = 'RX7HEzTc6dI'
   description = 'Password Hash'
   regex = '''\$2[abxy]\$[0-9]{2}\$[.\/A-Za-z0-9]{53}'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -856,7 +856,7 @@
   ]
 
 [[rules]]
-  id = 'a83ee4469a916041850c68b13b9d21dc85bfebc28b69b2f97273b61d5ba760fe'
+  id = 'amXYPF5An5s'
   description = 'Password Hash'
   regex = '''\$6\$(?:rounds=[1-9][0-9]+\$)?[^$:\n]{1,16}\$[.\/0-9A-Za-z]{86}'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -865,7 +865,7 @@
   ]
 
 [[rules]]
-  id = 'b402738f45253e5ebae94f8ed3d8ed5c8499ff6e2a5709ed7aae0e4e33116f3e'
+  id = 'u9MfgjhX7SI'
   description = 'Password Hash'
   regex = '''\$5\$(?:rounds=[1-9][0-9]+\$)?[^$:\n]{1,16}\$[.\/0-9A-Za-z]{43}'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -874,7 +874,7 @@
   ]
 
 [[rules]]
-  id = 'b9a128e8a1782a7670b73aac71f5a909d64c3e570ee700baddd8aa4afa0e7589'
+  id = 'iGgJnI-f5Xk'
   description = 'Password Hash'
   regex = '''\$md5(?:,rounds=[1-9][0-9]+)?\$[.\/0-9A-Za-z]{8}\${1,2}[.\/0-9A-Za-z]{22}'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -883,7 +883,7 @@
   ]
 
 [[rules]]
-  id = '65af234cecb9abc2f22a3cf70a11c3ebf952a95a70a33d79da9875e7158ff077'
+  id = 'AeVJW2sPHGs'
   description = 'Password Hash'
   regex = '''\$1\$[^$:\n]{1,8}\$[.\/0-9A-Za-z]{22}'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -892,7 +892,7 @@
   ]
 
 [[rules]]
-  id = '0e0e2ecf6a3b0b450004b49f0b7b7a1a3e67c07ff0465cc4363ade5d4ee43a76'
+  id = 'LSd2f7avYkQ'
   description = 'OpenAI API Key'
   regex = '''\b(sk-(?:proj-|svcacct-)?[A-Za-z0-9_\-]{32,80}T3BlbkFJ[A-Za-z0-9_\-]{32,})(?:[^A-Za-z0-9_\-]|$)'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -901,7 +901,7 @@
   ]
 
 [[rules]]
-  id = 'fe1cc0c882af5eac1fc66d4d357a6a9c508586fdb7d01f61c53f7ad926ccaa85'
+  id = 'RVee3wT2Z4I'
   description = 'Base64 Encoded OpenSSH Private Key'
   regex = '''[A-Za-z0-9+\/_\-]*?(?:QkVHSU4gT1BFTlNTSCBQUklW|JFR0lOIE9QRU5TU0ggUFJJV|CRUdJTiBPUEVOU1NIIFBSSV)[A-Za-z0-9+\/_\-\s]{256,}(?:RU5EIE9QRU5TU0ggUFJJV|VORCBPUEVOU1NIIFBSSV|FTkQgT1BFTlNTSCBQUklW)[A-Za-z0-9+\/_\-\s]*={0,3}'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -927,7 +927,7 @@
     ]
 
 [[rules]]
-  id = '18f3e8e86fa5995e6c64c1479f82019d34e4c076967cdfc1f759db0c783c4498'
+  id = 'NSjjvv0VeYg'
   description = 'PayPal Braintree Access Token'
   regex = '''access_token\$production\$[0-9a-z]{16}\$[0-9a-f]{32}'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -936,7 +936,7 @@
   ]
 
 [[rules]]
-  id = 'a84e30dd04b2e829ba75f341f16fb1f4bb2371f8e82e8442b14c594bbad482cb'
+  id = 'K3ZNQj2_kTE'
   description = 'Picatic API Key'
   regex = '''\bsk_live_[0-9a-z]{32}\b'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -945,13 +945,13 @@
   ]
 
 [[rules]]
-  id = 'f77b54d43771f272fb0b6e385431dfac83c3170c3105f353db7db4f3dcaa9587'
+  id = 'RA8jFaMQxIg'
   description = 'PKCS #12 File'
   path = '''(^|\/)[^\/]+\.p12$'''
   tags = ['type:secret', 'alert:repo-owner']
 
 [[rules]]
-  id = 'd5929654009ea640795908a2dcdb07f2f0ebbef42d1ac472bace4b4cd458ce98'
+  id = 'ePK9whPQPpY'
   description = 'Private Key'
   regex = '''(?i)-----BEGIN[ A-Z0-9_-]{0,100}PRIVATE KEY(?: BLOCK)?-----[\s\S]*?(?:[a-z0-9\/+]{64}[\s\S]*?){2}-----END[ A-Z0-9_-]{0,100}PRIVATE KEY(?: BLOCK)?-----'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -999,7 +999,7 @@
     ]
 
 [[rules]]
-  id = 'e28317dbb1b2104c7fca5911047d8315152fd6f230bd07d5188fc9e461154559'
+  id = 'ZeqrEVYyN7A'
   description = 'PyPI Upload Token'
   regex = '''pypi-AgEIcHlwaS5vcmc[A-Za-z0-9-_]{50,1000}'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -1008,7 +1008,7 @@
   ]
 
 [[rules]]
-  id = '76b4d3b89d4af399881204c7d8520e0c88a78f2662f31a3f674c51d4d64c8baa'
+  id = 'fJqKYcYx3bk'
   description = 'SendGrid API Key'
   regex = '''\bSG\.[\w\-]{16,32}\.[\w\-]{16,64}\b'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -1017,7 +1017,7 @@
   ]
 
 [[rules]]
-  id = '37a8264122df85941c43def588a1220665951ca17fcf91e8bccff786fc9f2ec7'
+  id = 'Rn1i7_84x3E'
   description = 'Shopify Access Token'
   regex = '''\bshpat_[a-fA-F0-9]{32}\b'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -1026,7 +1026,7 @@
   ]
 
 [[rules]]
-  id = '96e0c0f3da0e818283af13398ad43b51ff5be7c2c38dd6ef3b3bafae181dafb9'
+  id = '2yT2HilWNWU'
   description = 'Shopify Custom App Access Token'
   regex = '''\bshpca_[a-fA-F0-9]{32}\b'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -1035,7 +1035,7 @@
   ]
 
 [[rules]]
-  id = '7d4c55c2eaad8ec04d6c035009f797144c1f04b661d1054fced4e48771a90512'
+  id = 'Q3_9607B5YA'
   description = 'Shopify Private App Access Token'
   regex = '''\bshppa_[a-fA-F0-9]{32}\b'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -1044,7 +1044,7 @@
   ]
 
 [[rules]]
-  id = 'b840bb3f6dccc679a425bfa5573540fe3bacbed4d48f166dcfc496235025a40a'
+  id = 'xgtaj9NNvtQ'
   description = 'Shopify Shared Secret'
   regex = '''\bshpss_[a-fA-F0-9]{32}\b'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -1053,7 +1053,7 @@
   ]
 
 [[rules]]
-  id = '2f2bd1d768b6950cc2c4d84b0368c07fc423872e403bb4774a75e1d7072704d2'
+  id = 'PdsUpd2VsLw'
   description = 'Slack App Token'
   regex = '''(?i)\bxapp-\d-[a-z0-9]+-\d+-[a-z0-9]+\b'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -1071,7 +1071,7 @@
     ]
 
 [[rules]]
-  id = 'e94a2be853d40c0833ab7d9efa7e4c3987350be8044d82c2630de95b1aa512f2'
+  id = 'AHqBipAQalU'
   description = 'Slack Bot Token'
   regex = '''(?i)\bxoxb-[0-9]{10,13}\-[0-9]{10,13}[a-z0-9-]*\b'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -1089,7 +1089,7 @@
     ]
 
 [[rules]]
-  id = '5e4528622af53164487f2cefbe87742689bd324fcf555da4dae3ae8cf63339f2'
+  id = 'ADpHU5Pfr_w'
   description = 'Slack Config Access Token'
   regex = '''(?i)\bxoxe.xox[bp]-\d-[a-z0-9]{163,166}\b'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -1108,7 +1108,7 @@
     ]
 
 [[rules]]
-  id = '75cfb90cdc62deb6c3cc0109f72cb98651d404bc82d091c51e15601a1e01bfc4'
+  id = 'VitPJ4tk46E'
   description = 'Slack Config Refresh Token'
   regex = '''(?i)\bxoxe-\d-[a-z0-9]{146}\bj'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -1126,7 +1126,7 @@
     ]
 
 [[rules]]
-  id = '63986b8dff1459cb21692e28f9347aed55cb5f85ae21cc0c7227b710eb068cea'
+  id = 'qWJ75vwX7O8'
   description = 'Slack Legacy Bot Token'
   regex = '''(?i)\bxoxb-[0-9]{8,14}\-[a-z0-9]{18,26}\b'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -1144,7 +1144,7 @@
     ]
 
 [[rules]]
-  id = '1f21cc3e057a03719c1284c31a917bf1601ed1725b4a3d7cd2982560be6f46b7'
+  id = 'L7sVfqv1KDs'
   description = 'Slack Legacy Token'
   regex = '''(?i)\bxox[os]-\d+-\d+-\d+-[a-f\d]+\b'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -1163,7 +1163,7 @@
     ]
 
 [[rules]]
-  id = 'd1161f5f02c4ee44f2a3b0bf9dff89fe7b2986bf2aac52b62602d1fcd09a6b34'
+  id = 'Yjg2P_IaYK8'
   description = 'Slack Legacy Workspace Token'
   regex = '''(?i)\bxox[ar]-(?:\d-)?[0-9a-z]{8,48}\b'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -1182,7 +1182,7 @@
     ]
 
 [[rules]]
-  id = '71ecced1b8ebb3c4fd316f5ef68c0208703e7fd757b3548808dca2f585de5275'
+  id = '6mKbEmEYQDY'
   description = 'Slack User Token'
   regex = '''(?i)\bxox[pe](?:-[0-9]{10,13}){3}-[a-z0-9-]{28,34}\b'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -1201,7 +1201,7 @@
     ]
 
 [[rules]]
-  id = 'df8c74800f04ca32c33c1b94100e03a70ae0941c78c97ed556e71121781c91f6'
+  id = 'CPcj1txuB2g'
   description = 'Slack Webhook URL'
   regex = '''(?:https?:\/\/)?hooks.slack.com\/(?:services|workflows)\/[A-Za-z0-9+\/]{43,46}'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -1211,7 +1211,7 @@
   ]
 
 [[rules]]
-  id = '538346458f04daa723c81812eb5f5a84198efbba46e6aa01f4341d8bf325dac6'
+  id = 'pcwMvzsYJ5U'
   description = 'Snowflake OAuth Token'
   # Based on shifted b64 encoded portions any of:
   # - session:role-any
@@ -1232,7 +1232,7 @@
   ]
 
 [[rules]]
-  id = 'd4d9fc7b1e757e23c3bee62914079b1e1df294fafa025814db41be41d3312520'
+  id = 'FrTqjJHAoEY'
   description = 'StackRox JWT'
   # Based on shifted b64 encoded portions of '"iss":"https://stackrox.io/jwt"'
   regex = '''[a-zA-Z0-9-_]+\.[a-zA-Z0-9-_]+(?:ImlzcyI6Imh0dHBzOi8vc3RhY2tyb3guaW8vand0I|Jpc3MiOiJodHRwczovL3N0YWNrcm94LmlvL2p3dC|iaXNzIjoiaHR0cHM6Ly9zdGFja3JveC5pby9qd3Qi)[a-zA-Z0-9-_]+\.[a-zA-Z0-9-_]+'''
@@ -1244,7 +1244,7 @@
   ]
 
 [[rules]]
-  id = '7ff01b130235b65837366618698b00f6ae038c42f40ea2ef5ed3dd084b0703c6'
+  id = 'fZHzd4gAHrs'
   description = 'Square Access Token'
   regex = '''\bsq0atp-[0-9A-Za-z\-_]{22}'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -1253,7 +1253,7 @@
   ]
 
 [[rules]]
-  id = '8479e7e8807be5b1d3f57cad64bb6f7eede0f01d1819bf65ba5ab7867e12c869'
+  id = 'YX55Boo0gwk'
   description = 'Square OAuth Secret'
   regex = '''\bsq0csp-[0-9A-Za-z\\-_]{43}'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -1262,7 +1262,7 @@
   ]
 
 [[rules]]
-  id = '08786b3a6732a572e87937bee1a7b033c9d8a47893a1a5c488ae57a2b1edc191'
+  id = 'CSHGj8J1lUs'
   description = 'Stripe API Key'
   regex = '''(?i)\b[sr]k_live_[0-9a-zA-Z]{24}\b'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -1271,7 +1271,7 @@
   ]
 
 [[rules]]
-  id = '2fd47406ee312ed2fe6a9331f2d8759dca28f427cc71cba16e547e52c04ed60c'
+  id = 'lSFsU9hapFQ'
   description = 'Testing Farm API Token'
   regex = '''\bTESTING_FARM_API_TOKEN=[\"\']?([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\b'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -1280,7 +1280,7 @@
   ]
 
 [[rules]]
-  id = '44e5461c5358d708f9b9387d50c976907320173c36e6a68d52b61152d76d5da7'
+  id = 'TiwMt5e05g4'
   description = 'Tines Webhook'
   regex = '''(?i)(?:https:\/\/)?[\w\-]+\.tines\.com\/webhook\/[a-z0-9]{32}\/[a-z0-9]{32}'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -1289,7 +1289,7 @@
   ]
 
 [[rules]]
-  id = '5fd1363bdb194ec6981ebff1be9f2b5591c10f5f6acb7dbaf129b48df83d707e'
+  id = 'hRAjGfP0Zao'
   description = 'Twilio API Key'
   regex = '''\bSK(?i)[0-9a-f]{32}\b'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -1298,7 +1298,7 @@
   ]
 
 [[rules]]
-  id = '76475708ab8cf6060eb30ea8cb33e964d89860c3c4eb57dd64d583cf835be84e'
+  id = 'NoSStdj9pfY'
   description = 'URL User and Password'
   regex = '''[\w\+]*?:\/\/[^:\/\s\"\']*?:([^@\/\s\"]{3,})@[\w\.\-]+'''
   tags = ['type:secret', 'alert:repo-owner']
@@ -1390,7 +1390,7 @@
 
 
 [[rules]]
-  id = '2ed9686c92f697123e4a9e031c14544486247659900fe2806078110a5c0cf695'
+  id = 'FxXgdaIgf7Y'
   description = 'WP-Config'
   regex = '''define\s*?\(\s*?[\"\'](?:DB_HOST|DB_NAME|DB_USER|DB_PASSWORD|AUTH_KEY|SECURE_AUTH_KEY|LOGGED_IN_KEY|NONCE_KEY|AUTH_SALT|SECURE_AUTH_SALT|LOGGED_IN_SALT|NONCE_SALT)[\"\']\s*?,\s*?[\"\'](.+?)[\"\']\s*?\)'''
   tags = ['type:secret', 'alert:repo-owner']

--- a/patterns/gitleaks/8.18.2/99-testing.toml
+++ b/patterns/gitleaks/8.18.2/99-testing.toml
@@ -42,7 +42,7 @@
 # [file:98-general.toml]
 
 [[rules]]
-  id = '89a8be38a22feb55f458df682131f7d028c0f48885e8496f74cb3621337200b9'
+  id = 'hG-qMjbXGro'
   # Captures things like normal Generic Secret but handles the case where
   # the value is unquoted and in the format secret=value and has nothing
   # infront of it other than spaces or starts the line or is a comment
@@ -203,7 +203,7 @@
     ]
 
 [[rules]]
-  id = 'a4618135ef6270cf16be1c2aca72038a86e781645fa2df8e4d8165848bb7e943'
+  id = 'rZUmm0ozLWQ'
   description = 'HashiCorp Vault AppRole SecretID'
   regex = '''vault[\s\S]{0,128}secret_id[\'\"]?\s*[:=]\s*[\'\"]?([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\b'''
   tags = ['type:secret', 'group:leaktk-testing']
@@ -212,7 +212,7 @@
   ]
 
 [[rules]]
-  id = 'd6cdf13aa9b7b02a7f259b6f116bcbe24e4a30a01f566a418211c6e02e39fd79'
+  id = '-bDTAD8YMJg'
   description = 'Auth0 OAuth Client Secret'
   regex = '''(?i)auth0[\s\S]{0,128}client_?secret[\"\']?\s*\]?\s*[:=]\s*[\"\']?([a-zA-Z0-9_-]{64,})[\"\']?'''
   tags = ['type:secret', 'group:leaktk-testing']
@@ -222,7 +222,7 @@
   ]
 
 [[rules]]
-  id = '4467285558ee1cc8f1fd91a98bb0109432c4e7684851a2a616ba20ec8154fd9b'
+  id = 'o3-Wm5oL1D4'
   description = 'Auth0 JWT'
   # Based on base64 shifted segments of: ".auth0.com/",
   regex = '''[a-zA-Z0-9-_]+\.[a-zA-Z0-9-_]+(?:LmF1dGgwLmNvbS8iL|5hdXRoMC5jb20vIi|uYXV0aDAuY29tLyIs)[a-zA-Z0-9-_]+\.[a-zA-Z0-9-_]+'''
@@ -234,7 +234,7 @@
   ]
 
 [[rules]]
-  id = '6cb7e194180b90306cc5952b4e74698177970f9a3f121339476b9891805820ca'
+  id = 'qUN8svLm9sk'
   description = 'Dropbox Refresh Token'
   regex = '''(?:[^A-Za-z0-9]|\A)([A-Za-z0-9]{11}(AAAAAAAAAA)[A-Za-z0-9\-_=]{43})(?:[^A-Za-z0-9\-=_]|$)'''
   tags = ['type:secret', 'group:leaktk-testing']
@@ -243,7 +243,7 @@
   ]
 
 [[rules]]
-  id = '9e617f6025412a3b8d7dcd12e6242416c32c1524845239892612230b0ca227d5'
+  id = 'tvqG--ROt7U'
   description = 'Dropbox Short-Lived Offline Access Token'
   regex = '''(?i)(?:[^a-z0-9\-=_]|\A)(sl\.u.[a-z0-9\-=_]{136})(?:[^a-z0-9\-=_]|$)'''
   tags = ['type:secret', 'group:leaktk-testing']
@@ -252,7 +252,7 @@
   ]
 
 [[rules]]
-  id = 'eebe1f7351c8edb9aadc710be96072b4cf592aeaefe63a425fed3db21f04451f'
+  id = 'vtSSaD-DcYo'
   description = 'Dropbox Short-Lived Access Token'
   regex = '''(?i)(?:[^a-z0-9\-=_]|\A)(sl\.[a-z0-9\-=_]{136})(?:[^a-z0-9\-=_]|$)'''
   tags = ['type:secret', 'group:leaktk-testing']
@@ -261,7 +261,7 @@
   ]
 
 [[rules]]
-  id = '2c2cec078f547f39f2951ce131d2a18dcb5d9feb5d031679212b79f0d3cb5162'
+  id = 'zl044yuux24'
   description = 'Azure Active Directory Client Secret'
   regex = '''(?:[^a-zA-Z0-9_~.-]|\A)([a-zA-Z0-9_~.-]{3}\dQ~[a-zA-Z0-9_~.-]{31,34})(?:[^a-zA-Z0-9_~.-]|\z)'''
   tags = ['type:secret', 'group:leaktk-testing']
@@ -274,7 +274,7 @@
 # TODO: fix the scoping
 #
 # [[rules]]
-#   id = '0c46f7bbe4578544244b854d1329cb4fc181f42be956fd47397ae7b13b5490fe'
+#   id = 'lgA0jzBEvQo'
 #   description = 'Google Cloud Platform Service Account Credentials'
 #   # Should work multi line and require that at least 8 of the fields match
 #   # We may need to put allowlist items with regexTarget = 'match' for ignoring
@@ -298,7 +298,7 @@
 #   ]
 
 [[rules]]
-  id = '193ff72dae32b07dfa5773a929ba5d3f5bc166a8c4b5c10aa266c3fc613e545a'
+  id = 'QqS4RvI6Zmg'
   description = 'Authorization Header'
   regex = '''(?i)(?:\A|[^\w-])authorization:\s*(?:\w+\s+)?([^\s\"\']+)'''
   tags = ['type:secret', 'group:leaktk-testing']

--- a/scripts/check-dup-ids
+++ b/scripts/check-dup-ids
@@ -1,9 +1,10 @@
 #! /usr/bin/env bash
+set -euo pipefail
 patterns='target/patterns/gitleaks/8.18.2'
 
 for id in $(grep -Po "(?<=id = ').+?(?=')" < "${patterns}")
 do
-  id_count="$(grep "${id}" "${patterns}" | wc -l)"
+  id_count="$(grep -- "${id}" "${patterns}" | wc -l)"
 
   if [[ "${id_count}" -gt 1 ]]
   then

--- a/target/patterns/gitleaks/8.18.2
+++ b/target/patterns/gitleaks/8.18.2
@@ -21,7 +21,7 @@ paths = [
 '''(?:^|\/).yarn\/releases\/''',
 ]
 [[rules]]
-id = 'c42a367392fc3aadefbf9caa4de4582a790b8746ed72e6e97fca6f962502597a'
+id = 'nPY_Rcj4gzY'
 description = 'ArgoCD JWT'
 regex = '''[a-zA-Z0-9-_]+\.[a-zA-Z0-9-_]+(?:ImlzcyI6ImFyZ29jZC|Jpc3MiOiJhcmdvY2Qi|iaXNzIjoiYXJnb2NkI)[a-zA-Z0-9-_]+\.[a-zA-Z0-9-_]+'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -31,7 +31,7 @@ keywords = [
 'iaxnzijoiyxjnb2nki',
 ]
 [[rules]]
-id = 'ab58b5955845a843962cb6ac631b1d44a0cef6a37e060988e7e58b039706ca51'
+id = 'LAJoYTdoQH4'
 description = 'AWS IAM Unique Identifier'
 regex = '''(?:^|[^!$-&\(-9<>-~])((?:A3T[A-Z0-9]|ACCA|ABIA|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16})\b'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -60,7 +60,7 @@ regexes = [
 '''(?i)(?:sample|example).{0,128}\b(?:A3T[A-Z0-9]|ACCA|ABIA|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)(?:[A-Z0-9]{16})\b''',
 ]
 [[rules]]
-id = '308f20b091650166decc757badd05c51384601ac6d10c11d5282c37004fff959'
+id = '9j_rmwDeioM'
 description = 'AWS Secret Access Key'
 regex = '''(?i)aws[\w\-]{0,32}[\'\"]?\s*?[:=\(]\s*?[\'\"]?([a-z0-9\/+]{40})\b'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -95,7 +95,7 @@ regexes = [
 '''(?i)aws[\w\-]{0,32}[\'\"]?\s*?[:=\(]\s*?[\'\"]?[a-z0-9\/+]*(?-i)(?:RVhBTVBMR|VYQU1QTE|FWEFNUExF)''',
 ]
 [[rules]]
-id = '2eefe8aec9ce2ef59bd4e258d84ed17a0303dee93e6dffb49002acc877d33ee1'
+id = 'd01DtP9iA8I'
 description = 'Base64 Encoded AWS Secret Access Key'
 regex = '''[a-zA-Z0-9\/\+]*(?:YXdzX2FjY2Vzc19rZXlfaW|F3c19hY2Nlc3Nfa2V5X2lk|hd3NfYWNjZXNzX2tleV9pZ)[a-zA-Z0-9\/\+]*(?:QUtJQ|FLSU|BS0lB|UVV0Sl|FVdEpR|RVXRKU|RkxTV|ZMU1|GTFNV|QlMwbE|JTMGxC|CUzBsQ)[a-zA-Z0-9\/\+]*(?:YXdzX3NlY3JldF9hY2Nlc3Nfa2V5|F3c19zZWNyZXRfYWNjZXNzX2tle|hd3Nfc2VjcmV0X2FjY2Vzc19rZX)[a-zA-Z0-9\/\+]+={0,2}'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -105,7 +105,7 @@ keywords = [
 'hd3nfywnjzxnzx2tlev9pz',
 ]
 [[rules]]
-id = '3161082b147ad645b6d3637f68edcfa87949a79b45004efeef036e2cb7a0edfe'
+id = 'gpfGmO3HH64'
 description = 'Container Registry Authentication'
 regex = '''\\*\"auths\\*\"\s*:\s*\{\s*(?:\\*\"(?:[a-z0-9\-]{1,63}\.)+(?:[a-z0-9\-]{1,63})\\*\"\s*:\s*\{\s*\\*\"auth\\*\"\s*:\s*\\*\"[\w\/+-]{32,}={0,2}\\*\"[\s\S]*?\},?\s*)+\}'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -119,7 +119,7 @@ regexes = [
 '''\"email\\*\"\s*:\s*\\*\"[^"]*(?i)example[^"]*\\*\"''',
 ]
 [[rules]]
-id = 'e0e0ef11399b51b8efa864542979614bd1bb2288f3cb8bd2aa786e1a4aee9e79'
+id = 'me-TlU0uKS8'
 description = 'Dynatrace Token'
 regex = '''\bdt0[a-zA-Z]{1}[0-9]{2}\.[A-Z0-9]{24}\.[A-Z0-9]{64}\b'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -127,7 +127,7 @@ keywords = [
 'dt0',
 ]
 [[rules]]
-id = 'fc611155cdab32cb4ac3edf51045a9f73e066eee77c2c8d9771b29e7849212c0'
+id = 'bzBQF-LMlZU'
 description = 'Facebook Access Token'
 regex = '''\bEAACEdEose0cBA(?i)[a-z0-9]{128,256}\b'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -135,7 +135,7 @@ keywords = [
 'eaacedeose0cba',
 ]
 [[rules]]
-id = '13852bbfce4794be0e9740ef28cd7cb9d06776b8d6428e3b4e8350bb03260528'
+id = 'fdc8WJ7tfUA'
 description = 'Facebook Secret'
 regex = '''(?i)(?:facebook)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{32})(?:[\'\"\s\x60;,]|$)'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -143,7 +143,7 @@ keywords = [
 'facebook',
 ]
 [[rules]]
-id = '08147f6d4edc040aa8cc8d9313221aad0f0826de534f250b9987e6357bf8ae44'
+id = 'mC5kOxQ6kn4'
 description = 'Generic Secret'
 path = '''(?i)\.[\w\-]*(?:password|secret|token)$'''
 regex = '''[\S]{8,}'''
@@ -167,7 +167,7 @@ regexes = [
 '''^#!\s*\/''',
 ]
 [[rules]]
-id = 'cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22'
+id = '_-9w6-yrc-4'
 description = 'Generic Secret'
 regex = '''(?i)(?:password|secret|token)(?:_|-)?(?:access(?:_|-)?)?(?:key)?[\"\']?\s*?\]?\s*?[:=]\s*?[\"\']([^\"\s]+?)[\"\']'''
 entropy = 3.35
@@ -275,7 +275,7 @@ regexes = [
 '''[^A-Za-z0-9+\/]Ag[A-Za-z0-9+\/]{256,}''',
 ]
 [[rules]]
-id = 'a8d78f8de4bad0b519a8a14b625bc6d8ae3055bd8d8de6fc5c4b0b31bac4249e'
+id = 'eCOHX_SKGzA'
 description = 'Generic Secret'
 regex = '''(?i)<\s*?\w*?(?:password|secret|token)[\s\w\"\'=]*?>(?:<!\[CDATA\[)?([^\"\s]+?)(?:\]\]>)?<\/(?:[\s\w\"\'=]*?>)?'''
 entropy = 3.5
@@ -319,7 +319,7 @@ regexes = [
 '''(?i)<\s*?\w*?(?:password|secret|token)[\s\w\"\'=]*?>(?:<!\[CDATA\[)?(?:\\u[a-z0-9]{4})+(?:\]\]>)?<\/''',
 ]
 [[rules]]
-id = 'dd85b788ea6c12f4968c38091c2576ff17ce23565d8d14f2a3b34d44dccddec2'
+id = 'rnWF160pWNg'
 description = 'Generic Secret'
 path='''\.y(a)?ml$'''
 regex = '''(?i)(?:password|secret|token)(?:_|-)?(?:access(?:_|-)?)?(?:key)?:[\t\x20]+?([^\"\'\s]+?)\s*?(?:\n|#|$)'''
@@ -421,7 +421,7 @@ regexes = [
 '''\bAg[A-Za-z0-9+\/]{256,}''',
 ]
 [[rules]]
-id = 'f71af8c158940a1539bfb08feaa24e36bf584c9c819002ea989c6aa35319d2db'
+id = 'kX_PwM0MFvE'
 description = 'GitHub Fine-Grained Personal Access Token'
 regex = '''\bgithub_pat_\w{82}\b'''
 entropy = 2
@@ -430,7 +430,7 @@ keywords = [
 'github_pat_',
 ]
 [[rules]]
-id = '0e347181fa64a66c62628972058788e0caf23a3c6a5be7822a01f29b65a6a9f0'
+id = '3J1l0v_MrA0'
 description = 'GitHub OAuth Access Token'
 regex = '''\bgho_[0-9A-Za-z]{36}\b'''
 entropy = 2
@@ -439,7 +439,7 @@ keywords = [
 'gho_',
 ]
 [[rules]]
-id = 'a4ec986531bed1c154627c941eda6a95ef016481574cdfcb34249b648eb85ec7'
+id = 'gODCNuGzuKQ'
 description = 'GitHub Personal Access Token'
 regex = '''\bghp_[0-9A-Za-z]{36}\b'''
 entropy = 2
@@ -448,7 +448,7 @@ keywords = [
 'ghp_',
 ]
 [[rules]]
-id = '86141b0de6dfc25b4ff6fe7c74c9283367a1d1c9c2d4df99ad9b8948e5d462db'
+id = 'ReSYq_S3Ou0'
 description = 'GitHub Refresh Token'
 regex = '''\bghr_[0-9A-Za-z]{36}\b'''
 entropy = 2
@@ -457,7 +457,7 @@ keywords = [
 'ghr_',
 ]
 [[rules]]
-id = '357286368ed645f842a99b4b1bf585181a6edf2e466287fa97fa8e887729e614'
+id = 'YmXj5Lk-jw4'
 description = 'GitHub Server to Server Token'
 regex = '''\bghs_[0-9A-Za-z]{36}\b'''
 entropy = 2
@@ -466,7 +466,7 @@ keywords = [
 'ghs_',
 ]
 [[rules]]
-id = 'afe1c727a3b8fb95f9b4e08ff05d501c5faab40e3c621ebc95468bae6dfb7d1b'
+id = 'MMuUwURWAhM'
 description = 'GitHub User to Server Token'
 regex = '''\bghu_[0-9A-Za-z]{36}\b'''
 entropy = 2
@@ -475,7 +475,7 @@ keywords = [
 'ghu_',
 ]
 [[rules]]
-id = '0f6a47c693ad7a56c4a835f6aa7b38d18c343becae2f833fac2db51ecebd79e2'
+id = 'KJX2Vbp6_jY'
 description = 'GitLab Access Token'
 regex = '''\bglpat-[\w\-]{20}\b'''
 entropy = 2
@@ -484,7 +484,7 @@ keywords = [
 'glpat-',
 ]
 [[rules]]
-id = '798acef3dc3135b6c9482635a042cb405e3c050631ef0e3ccc3556dddc9254d1'
+id = 'IOimnsNGyvw'
 description = 'GitLab Pipeline Trigger Token'
 regex = '''\bglptt-[0-9a-f]{40}\b'''
 entropy = 2
@@ -493,7 +493,7 @@ keywords = [
 'glptt-',
 ]
 [[rules]]
-id = '7561d77130281f0e7b2339650a591ca94bf46c41dd9ca8cfe137fd4a1953d1b8'
+id = '5eH7BIYmpNo'
 description = 'GitLab Runner Registration Token'
 regex = '''\b(?:glrt-|GR1348941)[\w\-]{20}\b'''
 entropy = 2
@@ -503,7 +503,7 @@ keywords = [
 'gr1348941',
 ]
 [[rules]]
-id = '051eedb0bcb561306cadb6f5d310147c71edc1965d29b07ab38df8c54a623aba'
+id = 'HysINeDft8k'
 description = 'Google Cloud Platform API Key'
 regex = '''\bAIza[0-9A-Za-z\\-_]{35}\b'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -511,7 +511,7 @@ keywords = [
 'aiza',
 ]
 [[rules]]
-id = '33dc3d2c2470b17d9a29bd1f66d650f36dfab0e01ada76b8d7e254cd5da93ed9'
+id = 'F8ySDDFvEPA'
 description = 'Groq API Key'
 regex = '''\bgsk_[A-Za-z0-9]{52}\b'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -519,7 +519,7 @@ keywords = [
 'wgdyb3fy',
 ]
 [[rules]]
-id = '25a1be50e7c5c93b6f7d468adaadd6ff0f62dea6f60af64c9415f5b6ccbee8ce'
+id = '6Tfk9iWtINY'
 description = 'Heroku API Token'
 regex = '''(?i)heroku(?:.{0,20})?\b([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\b'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -527,7 +527,7 @@ keywords = [
 'heroku',
 ]
 [[rules]]
-id = '365926758922192ee27da4b29bc2cb6ee7b3af1bbf75cfd479283b57c909a58f'
+id = '8nWBN4ZoGf8'
 description = 'Htpasswd File'
 path = '''htpasswd[^\/]*?$'''
 regex = '''[^:\s]{1,255}:(\S{1,255})'''
@@ -542,7 +542,7 @@ regexes = [
 '''^\s*#''',
 ]
 [[rules]]
-id = '35dfcd9a65eaa32f3ba685014cdfc0963b411b48853263df5a5582bb3620d0fe'
+id = 'ROB1tToGkqM'
 description = 'Hugging Face API Token'
 regex = '''\bhf_[a-zA-Z]{34}\b'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -550,7 +550,7 @@ keywords = [
 'hf_',
 ]
 [[rules]]
-id = '50ed3470a6a293dd257ba4786f2e08da9e6eec64442c606f81859150f29e9b49'
+id = 'vAAom0bPHy8'
 description = 'Kubernetes System Service Account JWT'
 regex = '''[a-zA-Z0-9-_]+\.[a-zA-Z0-9-_]+(?:InN1YiI6InN5c3RlbTpzZXJ2aWNlYWNjb3VudD|JzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6|ic3ViIjoic3lzdGVtOnNlcnZpY2VhY2NvdW50O)[a-zA-Z0-9-_]+\.[a-zA-Z0-9-_]+'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -560,7 +560,7 @@ keywords = [
 'ic3viijoic3lzdgvtonnlcnzpy2vhy2nvdw50o',
 ]
 [[rules]]
-id = '0dc120e36dbbe5eec937807366ca120ce22e0ee28543f6e08fcb09039fb1b8dc'
+id = 'Evwi072oSOU'
 description = 'MailChimp API Key'
 regex = '''\b[0-9a-f]{32}-us[0-9]{1,2}\b'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -568,7 +568,7 @@ keywords = [
 '-us',
 ]
 [[rules]]
-id = '3bbe47102af6d87aaba1814062eae73dc0a840adcec38451a6cb5689d74a6961'
+id = '0Fj-HDkaBWM'
 description = 'Mailgun API Key'
 regex = '''(?i)(?:mailgun|mg).{0,20}?\b(key-[0-9a-z]{32})\b'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -577,7 +577,7 @@ keywords = [
 'key-',
 ]
 [[rules]]
-id = 'c23ef58e849f9272eddd95bb6f9ea503341d4b7f6f043088b227252e8ebefe8b'
+id = 'tBcMT24UjGQ'
 description = 'NPM Access Token'
 regex = '''\bnpm_[A-Za-z0-9]{36}\b'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -586,7 +586,7 @@ keywords = [
 'npm_',
 ]
 [[rules]]
-id = 'fd46ccfd70fb3b77859e535635c0fe3cb51c7d5be6f23f9cc40c5d0d226f59a1'
+id = 'tSFtnbvWdlk'
 description = 'NPM Registry Auth'
 regex = '''_(?:auth(?:Token)?|password)\s*=\s*(.+)'''
 path = '''(^|\/)[^\/]+npmrc$'''
@@ -602,7 +602,7 @@ regexes = [
 '''\$\{.+?\}''',
 ]
 [[rules]]
-id = '7c288b0becc8b6186eb504a34fc56ea0102837ee0aaa1e573c4c82fa7aec808c'
+id = 'DaAdIBwZoGE'
 description = 'OpenShift Login Token'
 regex='''\boc\s+login\s+.*?--token\s*=?\s*(sha256~[^<\s]{16,})\b'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -611,7 +611,7 @@ keywords = [
 '--token',
 ]
 [[rules]]
-id = '0f75ca0dd1fd85ed8160b8a693107cdf3904edf31d0985edf84fabf7500f2c2c'
+id = 'bYudTkTa56I'
 description = 'Password Hash'
 regex = '''\$y\$[.\/A-Za-z0-9]+\$[.\/A-Za-z0-9]{0,86}\$[.\/A-Za-z0-9]{43}'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -619,7 +619,7 @@ keywords = [
 '$y$',
 ]
 [[rules]]
-id = 'd843e3b5ee1a726c2570c8fb14e26509d699d8bb1aa2426b9c5ec6127670abac'
+id = 'fqtWnpN0lfA'
 description = 'Password Hash'
 regex = '''\$gy\$[.\/A-Za-z0-9]+\$[.\/A-Za-z0-9]{0,86}\$[.\/A-Za-z0-9]{43}'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -627,7 +627,7 @@ keywords = [
 '$gy$',
 ]
 [[rules]]
-id = 'e1074cf73d2a7d60b233984d261979b5d623277f03d0e334c67a71c99362c6c1'
+id = 'MxYvbqkT9IM'
 description = 'Password Hash'
 regex = '''\$7\$[.\/A-Za-z0-9]{11,97}\$[.\/A-Za-z0-9]{43}'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -635,7 +635,7 @@ keywords = [
 '$7$',
 ]
 [[rules]]
-id = 'a0e89d6e0593122ed5f0fcf19b54f480b63767b925a4c844f1da27dbf5462013'
+id = 'RX7HEzTc6dI'
 description = 'Password Hash'
 regex = '''\$2[abxy]\$[0-9]{2}\$[.\/A-Za-z0-9]{53}'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -646,7 +646,7 @@ keywords = [
 '$2y$',
 ]
 [[rules]]
-id = 'a83ee4469a916041850c68b13b9d21dc85bfebc28b69b2f97273b61d5ba760fe'
+id = 'amXYPF5An5s'
 description = 'Password Hash'
 regex = '''\$6\$(?:rounds=[1-9][0-9]+\$)?[^$:\n]{1,16}\$[.\/0-9A-Za-z]{86}'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -654,7 +654,7 @@ keywords = [
 '$6$',
 ]
 [[rules]]
-id = 'b402738f45253e5ebae94f8ed3d8ed5c8499ff6e2a5709ed7aae0e4e33116f3e'
+id = 'u9MfgjhX7SI'
 description = 'Password Hash'
 regex = '''\$5\$(?:rounds=[1-9][0-9]+\$)?[^$:\n]{1,16}\$[.\/0-9A-Za-z]{43}'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -662,7 +662,7 @@ keywords = [
 '$5$',
 ]
 [[rules]]
-id = 'b9a128e8a1782a7670b73aac71f5a909d64c3e570ee700baddd8aa4afa0e7589'
+id = 'iGgJnI-f5Xk'
 description = 'Password Hash'
 regex = '''\$md5(?:,rounds=[1-9][0-9]+)?\$[.\/0-9A-Za-z]{8}\${1,2}[.\/0-9A-Za-z]{22}'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -670,7 +670,7 @@ keywords = [
 '$md5',
 ]
 [[rules]]
-id = '65af234cecb9abc2f22a3cf70a11c3ebf952a95a70a33d79da9875e7158ff077'
+id = 'AeVJW2sPHGs'
 description = 'Password Hash'
 regex = '''\$1\$[^$:\n]{1,8}\$[.\/0-9A-Za-z]{22}'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -678,7 +678,7 @@ keywords = [
 '$1$',
 ]
 [[rules]]
-id = '0e0e2ecf6a3b0b450004b49f0b7b7a1a3e67c07ff0465cc4363ade5d4ee43a76'
+id = 'LSd2f7avYkQ'
 description = 'OpenAI API Key'
 regex = '''\b(sk-(?:proj-|svcacct-)?[A-Za-z0-9_\-]{32,80}T3BlbkFJ[A-Za-z0-9_\-]{32,})(?:[^A-Za-z0-9_\-]|$)'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -686,7 +686,7 @@ keywords = [
 't3blbkfj',
 ]
 [[rules]]
-id = 'fe1cc0c882af5eac1fc66d4d357a6a9c508586fdb7d01f61c53f7ad926ccaa85'
+id = 'RVee3wT2Z4I'
 description = 'Base64 Encoded OpenSSH Private Key'
 regex = '''[A-Za-z0-9+\/_\-]*?(?:QkVHSU4gT1BFTlNTSCBQUklW|JFR0lOIE9QRU5TU0ggUFJJV|CRUdJTiBPUEVOU1NIIFBSSV)[A-Za-z0-9+\/_\-\s]{256,}(?:RU5EIE9QRU5TU0ggUFJJV|VORCBPUEVOU1NIIFBSSV|FTkQgT1BFTlNTSCBQUklW)[A-Za-z0-9+\/_\-\s]*={0,3}'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -708,7 +708,7 @@ stopwords = [
 'fwefnuexf',
 ]
 [[rules]]
-id = '18f3e8e86fa5995e6c64c1479f82019d34e4c076967cdfc1f759db0c783c4498'
+id = 'NSjjvv0VeYg'
 description = 'PayPal Braintree Access Token'
 regex = '''access_token\$production\$[0-9a-z]{16}\$[0-9a-f]{32}'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -716,7 +716,7 @@ keywords = [
 'access_token$production$',
 ]
 [[rules]]
-id = 'a84e30dd04b2e829ba75f341f16fb1f4bb2371f8e82e8442b14c594bbad482cb'
+id = 'K3ZNQj2_kTE'
 description = 'Picatic API Key'
 regex = '''\bsk_live_[0-9a-z]{32}\b'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -724,12 +724,12 @@ keywords = [
 'sk_live_',
 ]
 [[rules]]
-id = 'f77b54d43771f272fb0b6e385431dfac83c3170c3105f353db7db4f3dcaa9587'
+id = 'RA8jFaMQxIg'
 description = 'PKCS #12 File'
 path = '''(^|\/)[^\/]+\.p12$'''
 tags = ['type:secret', 'alert:repo-owner']
 [[rules]]
-id = 'd5929654009ea640795908a2dcdb07f2f0ebbef42d1ac472bace4b4cd458ce98'
+id = 'ePK9whPQPpY'
 description = 'Private Key'
 regex = '''(?i)-----BEGIN[ A-Z0-9_-]{0,100}PRIVATE KEY(?: BLOCK)?-----[\s\S]*?(?:[a-z0-9\/+]{64}[\s\S]*?){2}-----END[ A-Z0-9_-]{0,100}PRIVATE KEY(?: BLOCK)?-----'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -758,7 +758,7 @@ regexes = [
 '''#\s*?noqa(:[\s\w]+)?$''',
 ]
 [[rules]]
-id = 'e28317dbb1b2104c7fca5911047d8315152fd6f230bd07d5188fc9e461154559'
+id = 'ZeqrEVYyN7A'
 description = 'PyPI Upload Token'
 regex = '''pypi-AgEIcHlwaS5vcmc[A-Za-z0-9-_]{50,1000}'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -766,7 +766,7 @@ keywords = [
 'pypi-ageichlwas5vcmc',
 ]
 [[rules]]
-id = '76b4d3b89d4af399881204c7d8520e0c88a78f2662f31a3f674c51d4d64c8baa'
+id = 'fJqKYcYx3bk'
 description = 'SendGrid API Key'
 regex = '''\bSG\.[\w\-]{16,32}\.[\w\-]{16,64}\b'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -774,7 +774,7 @@ keywords = [
 'sg.',
 ]
 [[rules]]
-id = '37a8264122df85941c43def588a1220665951ca17fcf91e8bccff786fc9f2ec7'
+id = 'Rn1i7_84x3E'
 description = 'Shopify Access Token'
 regex = '''\bshpat_[a-fA-F0-9]{32}\b'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -782,7 +782,7 @@ keywords = [
 'shpat_',
 ]
 [[rules]]
-id = '96e0c0f3da0e818283af13398ad43b51ff5be7c2c38dd6ef3b3bafae181dafb9'
+id = '2yT2HilWNWU'
 description = 'Shopify Custom App Access Token'
 regex = '''\bshpca_[a-fA-F0-9]{32}\b'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -790,7 +790,7 @@ keywords = [
 'shpca_',
 ]
 [[rules]]
-id = '7d4c55c2eaad8ec04d6c035009f797144c1f04b661d1054fced4e48771a90512'
+id = 'Q3_9607B5YA'
 description = 'Shopify Private App Access Token'
 regex = '''\bshppa_[a-fA-F0-9]{32}\b'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -798,7 +798,7 @@ keywords = [
 'shppa_',
 ]
 [[rules]]
-id = 'b840bb3f6dccc679a425bfa5573540fe3bacbed4d48f166dcfc496235025a40a'
+id = 'xgtaj9NNvtQ'
 description = 'Shopify Shared Secret'
 regex = '''\bshpss_[a-fA-F0-9]{32}\b'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -806,7 +806,7 @@ keywords = [
 'shpss_',
 ]
 [[rules]]
-id = '2f2bd1d768b6950cc2c4d84b0368c07fc423872e403bb4774a75e1d7072704d2'
+id = 'PdsUpd2VsLw'
 description = 'Slack App Token'
 regex = '''(?i)\bxapp-\d-[a-z0-9]+-\d+-[a-z0-9]+\b'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -822,7 +822,7 @@ stopwords = [
 'slack',
 ]
 [[rules]]
-id = 'e94a2be853d40c0833ab7d9efa7e4c3987350be8044d82c2630de95b1aa512f2'
+id = 'AHqBipAQalU'
 description = 'Slack Bot Token'
 regex = '''(?i)\bxoxb-[0-9]{10,13}\-[0-9]{10,13}[a-z0-9-]*\b'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -838,7 +838,7 @@ stopwords = [
 'slack',
 ]
 [[rules]]
-id = '5e4528622af53164487f2cefbe87742689bd324fcf555da4dae3ae8cf63339f2'
+id = 'ADpHU5Pfr_w'
 description = 'Slack Config Access Token'
 regex = '''(?i)\bxoxe.xox[bp]-\d-[a-z0-9]{163,166}\b'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -855,7 +855,7 @@ stopwords = [
 'slack',
 ]
 [[rules]]
-id = '75cfb90cdc62deb6c3cc0109f72cb98651d404bc82d091c51e15601a1e01bfc4'
+id = 'VitPJ4tk46E'
 description = 'Slack Config Refresh Token'
 regex = '''(?i)\bxoxe-\d-[a-z0-9]{146}\bj'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -871,7 +871,7 @@ stopwords = [
 'slack',
 ]
 [[rules]]
-id = '63986b8dff1459cb21692e28f9347aed55cb5f85ae21cc0c7227b710eb068cea'
+id = 'qWJ75vwX7O8'
 description = 'Slack Legacy Bot Token'
 regex = '''(?i)\bxoxb-[0-9]{8,14}\-[a-z0-9]{18,26}\b'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -887,7 +887,7 @@ stopwords = [
 'slack',
 ]
 [[rules]]
-id = '1f21cc3e057a03719c1284c31a917bf1601ed1725b4a3d7cd2982560be6f46b7'
+id = 'L7sVfqv1KDs'
 description = 'Slack Legacy Token'
 regex = '''(?i)\bxox[os]-\d+-\d+-\d+-[a-f\d]+\b'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -904,7 +904,7 @@ stopwords = [
 'slack',
 ]
 [[rules]]
-id = 'd1161f5f02c4ee44f2a3b0bf9dff89fe7b2986bf2aac52b62602d1fcd09a6b34'
+id = 'Yjg2P_IaYK8'
 description = 'Slack Legacy Workspace Token'
 regex = '''(?i)\bxox[ar]-(?:\d-)?[0-9a-z]{8,48}\b'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -921,7 +921,7 @@ stopwords = [
 'slack',
 ]
 [[rules]]
-id = '71ecced1b8ebb3c4fd316f5ef68c0208703e7fd757b3548808dca2f585de5275'
+id = '6mKbEmEYQDY'
 description = 'Slack User Token'
 regex = '''(?i)\bxox[pe](?:-[0-9]{10,13}){3}-[a-z0-9-]{28,34}\b'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -938,7 +938,7 @@ stopwords = [
 'slack',
 ]
 [[rules]]
-id = 'df8c74800f04ca32c33c1b94100e03a70ae0941c78c97ed556e71121781c91f6'
+id = 'CPcj1txuB2g'
 description = 'Slack Webhook URL'
 regex = '''(?:https?:\/\/)?hooks.slack.com\/(?:services|workflows)\/[A-Za-z0-9+\/]{43,46}'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -947,7 +947,7 @@ keywords = [
 'hooks.slack.com',
 ]
 [[rules]]
-id = '538346458f04daa723c81812eb5f5a84198efbba46e6aa01f4341d8bf325dac6'
+id = 'pcwMvzsYJ5U'
 description = 'Snowflake OAuth Token'
 regex = '''[a-zA-Z0-9-_]+\.[a-zA-Z0-9-_]+(?:c2Vzc2lvbjpyb2xlLWFue|Nlc3Npb246cm9sZS1hbn|zZXNzaW9uOnJvbGUtYW55|c2Vzc2lvbjpyb2xlO|Nlc3Npb246cm9sZT|zZXNzaW9uOnJvbGU6|ImF1ZCI6InNub3dmbGFrZS|JhdWQiOiJzbm93Zmxha2Ug|iYXVkIjoic25vd2ZsYWtlI)[a-zA-Z0-9-_]+\.[a-zA-Z0-9-_]+'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -963,7 +963,7 @@ keywords = [
 'iyxvkijoic25vd2zsywtli',
 ]
 [[rules]]
-id = 'd4d9fc7b1e757e23c3bee62914079b1e1df294fafa025814db41be41d3312520'
+id = 'FrTqjJHAoEY'
 description = 'StackRox JWT'
 regex = '''[a-zA-Z0-9-_]+\.[a-zA-Z0-9-_]+(?:ImlzcyI6Imh0dHBzOi8vc3RhY2tyb3guaW8vand0I|Jpc3MiOiJodHRwczovL3N0YWNrcm94LmlvL2p3dC|iaXNzIjoiaHR0cHM6Ly9zdGFja3JveC5pby9qd3Qi)[a-zA-Z0-9-_]+\.[a-zA-Z0-9-_]+'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -973,7 +973,7 @@ keywords = [
 'iaxnzijoiahr0chm6ly9zdgfja3jvec5pby9qd3qi',
 ]
 [[rules]]
-id = '7ff01b130235b65837366618698b00f6ae038c42f40ea2ef5ed3dd084b0703c6'
+id = 'fZHzd4gAHrs'
 description = 'Square Access Token'
 regex = '''\bsq0atp-[0-9A-Za-z\-_]{22}'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -981,7 +981,7 @@ keywords = [
 'sq0atp-',
 ]
 [[rules]]
-id = '8479e7e8807be5b1d3f57cad64bb6f7eede0f01d1819bf65ba5ab7867e12c869'
+id = 'YX55Boo0gwk'
 description = 'Square OAuth Secret'
 regex = '''\bsq0csp-[0-9A-Za-z\\-_]{43}'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -989,7 +989,7 @@ keywords = [
 'sq0csp-',
 ]
 [[rules]]
-id = '08786b3a6732a572e87937bee1a7b033c9d8a47893a1a5c488ae57a2b1edc191'
+id = 'CSHGj8J1lUs'
 description = 'Stripe API Key'
 regex = '''(?i)\b[sr]k_live_[0-9a-zA-Z]{24}\b'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -997,7 +997,7 @@ keywords = [
 'k_live_',
 ]
 [[rules]]
-id = '2fd47406ee312ed2fe6a9331f2d8759dca28f427cc71cba16e547e52c04ed60c'
+id = 'lSFsU9hapFQ'
 description = 'Testing Farm API Token'
 regex = '''\bTESTING_FARM_API_TOKEN=[\"\']?([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\b'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -1005,7 +1005,7 @@ keywords = [
 'testing_farm_api_token',
 ]
 [[rules]]
-id = '44e5461c5358d708f9b9387d50c976907320173c36e6a68d52b61152d76d5da7'
+id = 'TiwMt5e05g4'
 description = 'Tines Webhook'
 regex = '''(?i)(?:https:\/\/)?[\w\-]+\.tines\.com\/webhook\/[a-z0-9]{32}\/[a-z0-9]{32}'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -1013,7 +1013,7 @@ keywords = [
 '.tines.com/webhook/',
 ]
 [[rules]]
-id = '5fd1363bdb194ec6981ebff1be9f2b5591c10f5f6acb7dbaf129b48df83d707e'
+id = 'hRAjGfP0Zao'
 description = 'Twilio API Key'
 regex = '''\bSK(?i)[0-9a-f]{32}\b'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -1021,7 +1021,7 @@ keywords = [
 'sk',
 ]
 [[rules]]
-id = '76475708ab8cf6060eb30ea8cb33e964d89860c3c4eb57dd64d583cf835be84e'
+id = 'NoSStdj9pfY'
 description = 'URL User and Password'
 regex = '''[\w\+]*?:\/\/[^:\/\s\"\']*?:([^@\/\s\"]{3,})@[\w\.\-]+'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -1088,7 +1088,7 @@ regexes = [
 '''re\.compile\(\s*?r?[\'\"]''',
 ]
 [[rules]]
-id = '2ed9686c92f697123e4a9e031c14544486247659900fe2806078110a5c0cf695'
+id = 'FxXgdaIgf7Y'
 description = 'WP-Config'
 regex = '''define\s*?\(\s*?[\"\'](?:DB_HOST|DB_NAME|DB_USER|DB_PASSWORD|AUTH_KEY|SECURE_AUTH_KEY|LOGGED_IN_KEY|NONCE_KEY|AUTH_SALT|SECURE_AUTH_SALT|LOGGED_IN_SALT|NONCE_SALT)[\"\']\s*?,\s*?[\"\'](.+?)[\"\']\s*?\)'''
 tags = ['type:secret', 'alert:repo-owner']
@@ -1113,7 +1113,7 @@ regexes = [
 '''^(?:<.+?>|\{\{.+?\}\}|\$\{.+?\}|\$\w+)$''',
 ]
 [[rules]]
-id = '89a8be38a22feb55f458df682131f7d028c0f48885e8496f74cb3621337200b9'
+id = 'hG-qMjbXGro'
 description = '(Env Var) Generic Secret'
 regex = '''(?i)(?:^|\n)[#\s]*?\w*?(?:(?:password|secret|token)_?(?:access_?)?(?:key)?|api_?key)=([^\s\"\']{6,})'''
 entropy = 3.35
@@ -1216,7 +1216,7 @@ regexes = [
 '''(?i)(?:mailgun|mg).{0,20}?\b(key-[0-9a-z]{32})\b''',
 ]
 [[rules]]
-id = 'a4618135ef6270cf16be1c2aca72038a86e781645fa2df8e4d8165848bb7e943'
+id = 'rZUmm0ozLWQ'
 description = 'HashiCorp Vault AppRole SecretID'
 regex = '''vault[\s\S]{0,128}secret_id[\'\"]?\s*[:=]\s*[\'\"]?([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\b'''
 tags = ['type:secret', 'group:leaktk-testing']
@@ -1224,7 +1224,7 @@ keywords = [
 'secret_id',
 ]
 [[rules]]
-id = 'd6cdf13aa9b7b02a7f259b6f116bcbe24e4a30a01f566a418211c6e02e39fd79'
+id = '-bDTAD8YMJg'
 description = 'Auth0 OAuth Client Secret'
 regex = '''(?i)auth0[\s\S]{0,128}client_?secret[\"\']?\s*\]?\s*[:=]\s*[\"\']?([a-zA-Z0-9_-]{64,})[\"\']?'''
 tags = ['type:secret', 'group:leaktk-testing']
@@ -1233,7 +1233,7 @@ keywords = [
 'clientsecret',
 ]
 [[rules]]
-id = '4467285558ee1cc8f1fd91a98bb0109432c4e7684851a2a616ba20ec8154fd9b'
+id = 'o3-Wm5oL1D4'
 description = 'Auth0 JWT'
 regex = '''[a-zA-Z0-9-_]+\.[a-zA-Z0-9-_]+(?:LmF1dGgwLmNvbS8iL|5hdXRoMC5jb20vIi|uYXV0aDAuY29tLyIs)[a-zA-Z0-9-_]+\.[a-zA-Z0-9-_]+'''
 tags = ['type:secret', 'group:leaktk-testing']
@@ -1243,7 +1243,7 @@ keywords = [
 'uyxv0adauy29tlyis',
 ]
 [[rules]]
-id = '6cb7e194180b90306cc5952b4e74698177970f9a3f121339476b9891805820ca'
+id = 'qUN8svLm9sk'
 description = 'Dropbox Refresh Token'
 regex = '''(?:[^A-Za-z0-9]|\A)([A-Za-z0-9]{11}(AAAAAAAAAA)[A-Za-z0-9\-_=]{43})(?:[^A-Za-z0-9\-=_]|$)'''
 tags = ['type:secret', 'group:leaktk-testing']
@@ -1251,7 +1251,7 @@ keywords = [
 'dropbox',
 ]
 [[rules]]
-id = '9e617f6025412a3b8d7dcd12e6242416c32c1524845239892612230b0ca227d5'
+id = 'tvqG--ROt7U'
 description = 'Dropbox Short-Lived Offline Access Token'
 regex = '''(?i)(?:[^a-z0-9\-=_]|\A)(sl\.u.[a-z0-9\-=_]{136})(?:[^a-z0-9\-=_]|$)'''
 tags = ['type:secret', 'group:leaktk-testing']
@@ -1259,7 +1259,7 @@ keywords = [
 'sl.u.',
 ]
 [[rules]]
-id = 'eebe1f7351c8edb9aadc710be96072b4cf592aeaefe63a425fed3db21f04451f'
+id = 'vtSSaD-DcYo'
 description = 'Dropbox Short-Lived Access Token'
 regex = '''(?i)(?:[^a-z0-9\-=_]|\A)(sl\.[a-z0-9\-=_]{136})(?:[^a-z0-9\-=_]|$)'''
 tags = ['type:secret', 'group:leaktk-testing']
@@ -1267,14 +1267,14 @@ keywords = [
 'sl.',
 ]
 [[rules]]
-id = '2c2cec078f547f39f2951ce131d2a18dcb5d9feb5d031679212b79f0d3cb5162'
+id = 'zl044yuux24'
 description = 'Azure Active Directory Client Secret'
 regex = '''(?:[^a-zA-Z0-9_~.-]|\A)([a-zA-Z0-9_~.-]{3}\dQ~[a-zA-Z0-9_~.-]{31,34})(?:[^a-zA-Z0-9_~.-]|\z)'''
 tags = ['type:secret', 'group:leaktk-testing']
 entropy = 3
 secretGroup = 1
 [[rules]]
-id = '193ff72dae32b07dfa5773a929ba5d3f5bc166a8c4b5c10aa266c3fc613e545a'
+id = 'QqS4RvI6Zmg'
 description = 'Authorization Header'
 regex = '''(?i)(?:\A|[^\w-])authorization:\s*(?:\w+\s+)?([^\s\"\']+)'''
 tags = ['type:secret', 'group:leaktk-testing']

--- a/testdata/leaktk-scanner-results.yaml
+++ b/testdata/leaktk-scanner-results.yaml
@@ -5,97 +5,97 @@
 #
 
 - rule.description: (Env Var) Generic Secret
-  rule.id: 89a8be38a22feb55f458df682131f7d028c0f48885e8496f74cb3621337200b9
+  rule.id: hG-qMjbXGro
   location.path: azure/valid/ad-keys.env
   match: AZURE_CLIENT_SECRET=3~K7Q~yxHSpLEt8z5YsP~pMcmAMOPlwxG4JcXbT
   secret: 3~K7Q~yxHSpLEt8z5YsP~pMcmAMOPlwxG4JcXbT
 
 - rule.description: (Env Var) Generic Secret
-  rule.id: 89a8be38a22feb55f458df682131f7d028c0f48885e8496f74cb3621337200b9
+  rule.id: hG-qMjbXGro
   location.path: foo/libexec/sudo/sudoers.so
   match: password=V1tXb7WBGlKIVAWqGw==
   secret: V1tXb7WBGlKIVAWqGw==
 
 - rule.description: (Env Var) Generic Secret
-  rule.id: 89a8be38a22feb55f458df682131f7d028c0f48885e8496f74cb3621337200b9
+  rule.id: hG-qMjbXGro
   location.path: general-test
   match: api_key=1b3d576ba5a108c3b7374142bfd02992
   secret: 1b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: (Env Var) Generic Secret
-  rule.id: 89a8be38a22feb55f458df682131f7d028c0f48885e8496f74cb3621337200b9
+  rule.id: hG-qMjbXGro
   location.path: general-test
   match: api_key=2b3d576ba5a108c3b7374142bfd02992
   secret: 2b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: (Env Var) Generic Secret
-  rule.id: 89a8be38a22feb55f458df682131f7d028c0f48885e8496f74cb3621337200b9
+  rule.id: hG-qMjbXGro
   location.path: general-test
   match: api_key=3b3d576ba5a108c3b7374142bfd02992
   secret: 3b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: (Env Var) Generic Secret
-  rule.id: 89a8be38a22feb55f458df682131f7d028c0f48885e8496f74cb3621337200b9
+  rule.id: hG-qMjbXGro
   location.path: general-test
   match: api_key=4b3d576ba5a108c3b7374142bfd02992
   secret: 4b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: (Env Var) Generic Secret
-  rule.id: 89a8be38a22feb55f458df682131f7d028c0f48885e8496f74cb3621337200b9
+  rule.id: hG-qMjbXGro
   location.path: general-test
   match: api_key=5b3d576ba5a108c3b7374142bfd02992
   secret: 5b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: (Env Var) Generic Secret
-  rule.id: 89a8be38a22feb55f458df682131f7d028c0f48885e8496f74cb3621337200b9
+  rule.id: hG-qMjbXGro
   location.path: general-test
   match: api_key=swke6BX0-14v3rYb2Ix32AIfTh9j_H_671dcf8gjpdTbsThiJfxapnAqFs8_kiW4ME-ZPxLmVEgmTxxwlb8Xvw
   secret: swke6BX0-14v3rYb2Ix32AIfTh9j_H_671dcf8gjpdTbsThiJfxapnAqFs8_kiW4ME-ZPxLmVEgmTxxwlb8Xvw
 
 - rule.description: (Env Var) Generic Secret
-  rule.id: 89a8be38a22feb55f458df682131f7d028c0f48885e8496f74cb3621337200b9
+  rule.id: hG-qMjbXGro
   location.path: general-test
   match: secret=1b3d576ba5a108c3b7374142bfd02992
   secret: 1b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: (Env Var) Generic Secret
-  rule.id: 89a8be38a22feb55f458df682131f7d028c0f48885e8496f74cb3621337200b9
+  rule.id: hG-qMjbXGro
   location.path: general-test
   match: secret=2b3d576ba5a108c3b7374142bfd02992
   secret: 2b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: (Env Var) Generic Secret
-  rule.id: 89a8be38a22feb55f458df682131f7d028c0f48885e8496f74cb3621337200b9
+  rule.id: hG-qMjbXGro
   location.path: general-test
   match: secret=3b3d576ba5a108c3b7374142bfd02992
   secret: 3b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: (Env Var) Generic Secret
-  rule.id: 89a8be38a22feb55f458df682131f7d028c0f48885e8496f74cb3621337200b9
+  rule.id: hG-qMjbXGro
   location.path: general-test
   match: secret=4b3d576ba5a108c3b7374142bfd02992
   secret: 4b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: (Env Var) Generic Secret
-  rule.id: 89a8be38a22feb55f458df682131f7d028c0f48885e8496f74cb3621337200b9
+  rule.id: hG-qMjbXGro
   location.path: general-test
   match: secret=5b3d576ba5a108c3b7374142bfd02992
   secret: 5b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: (Env Var) Generic Secret
-  rule.id: 89a8be38a22feb55f458df682131f7d028c0f48885e8496f74cb3621337200b9
+  rule.id: hG-qMjbXGro
   location.path: general-test
   match: secret=swke6BX0-14v3rYb2Ix32AIfTh9j_H_671dcf8gjpdTbsThiJfxapnAqFs8_kiW4ME-ZPxLmVEgmTxxwlb8Xvw
   secret: swke6BX0-14v3rYb2Ix32AIfTh9j_H_671dcf8gjpdTbsThiJfxapnAqFs8_kiW4ME-ZPxLmVEgmTxxwlb8Xvw
 
 - rule.description: (Env Var) Generic Secret
-  rule.id: 89a8be38a22feb55f458df682131f7d028c0f48885e8496f74cb3621337200b9
+  rule.id: hG-qMjbXGro
   location.path: some-file
   match: secret=c007cd12-1fe7-4843-947e-ddecfc0d8913
   secret: c007cd12-1fe7-4843-947e-ddecfc0d8913
 
 - rule.description: (Env Var) Generic Secret
-  rule.id: 89a8be38a22feb55f458df682131f7d028c0f48885e8496f74cb3621337200b9
+  rule.id: hG-qMjbXGro
   location.path: some.yaml
   match: secret=c007cd12-1fe7-4843-947e-ddecfc0d8913
   secret: c007cd12-1fe7-4843-947e-ddecfc0d8913
@@ -105,19 +105,19 @@
 #
 
 - rule.description: AWS IAM Unique Identifier
-  rule.id: ab58b5955845a843962cb6ac631b1d44a0cef6a37e060988e7e58b039706ca51
+  rule.id: LAJoYTdoQH4
   location.path: general-test
   match: =A3TGOBTGY4DIMRXMIYGE
   secret: A3TGOBTGY4DIMRXMIYGE
 
 - rule.description: AWS IAM Unique Identifier
-  rule.id: ab58b5955845a843962cb6ac631b1d44a0cef6a37e060988e7e58b039706ca51
+  rule.id: LAJoYTdoQH4
   location.path: semgrep-rules-examples/detected-aws-access-key-id-value.txt
   match: AKIAIOSFODNN7EAXMPLE
   secret: AKIAIOSFODNN7EAXMPLE
 
 - rule.description: AWS IAM Unique Identifier
-  rule.id: ab58b5955845a843962cb6ac631b1d44a0cef6a37e060988e7e58b039706ca51
+  rule.id: LAJoYTdoQH4
   location.path: semgrep-rules-examples/detected-aws-access-key-id-value.txt
   match: ASIAIOSFODNN7EAXMPLE
   secret: ASIAIOSFODNN7EAXMPLE
@@ -127,31 +127,31 @@
 #
 
 - rule.description: AWS Secret Access Key
-  rule.id: 308f20b091650166decc757badd05c51384601ac6d10c11d5282c37004fff959
+  rule.id: 9j_rmwDeioM
   location.path: general-test
   match: AWSSecretKey="aF6/f1+2a534df0cc1e4d892b5768f3easefaszb
   secret: aF6/f1+2a534df0cc1e4d892b5768f3easefaszb
 
 - rule.description: AWS Secret Access Key
-  rule.id: 308f20b091650166decc757badd05c51384601ac6d10c11d5282c37004fff959
+  rule.id: 9j_rmwDeioM
   location.path: general-test
   match: AWSSecretKey=af60f112a534df0cc1e4d892b5768f3easefasza
   secret: af60f112a534df0cc1e4d892b5768f3easefasza
 
 - rule.description: AWS Secret Access Key
-  rule.id: 308f20b091650166decc757badd05c51384601ac6d10c11d5282c37004fff959
+  rule.id: 9j_rmwDeioM
   location.path: general-test
   match: 'aws_secret_key": "Af60f112a534df0cc1e4d892b5768f3easef/+zc'
   secret: Af60f112a534df0cc1e4d892b5768f3easef/+zc
 
 - rule.description: AWS Secret Access Key
-  rule.id: 308f20b091650166decc757badd05c51384601ac6d10c11d5282c37004fff959
+  rule.id: 9j_rmwDeioM
   location.path: semgrep-rules-examples/detected-aws-secret-access-key.txt
   match: aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEFUCDlEKEY
   secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEFUCDlEKEY
 
 - rule.description: AWS Secret Access Key
-  rule.id: 308f20b091650166decc757badd05c51384601ac6d10c11d5282c37004fff959
+  rule.id: 9j_rmwDeioM
   location.path: semgrep-rules-examples/detected-aws-secret-access-key.txt
   match: aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEFUCDlEKEY
   secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEFUCDlEKEY
@@ -161,19 +161,19 @@
 #
 
 - rule.description: ArgoCD JWT
-  rule.id: c42a367392fc3aadefbf9caa4de4582a790b8746ed72e6e97fca6f962502597a
+  rule.id: nPY_Rcj4gzY
   location.path: general-test
   match: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJsZWFrdGsiLCJub3RlIjoiZm9yIHRlc3RpbmcgQXJnb0NEIG1hdGNoZXMiLCJ4IjoieCIsImlzcyI6ImFyZ29jZCJ9.kHldeGEECY3basc-aTT-3eQvellg8T02h8M02M3v3c0
   secret: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJsZWFrdGsiLCJub3RlIjoiZm9yIHRlc3RpbmcgQXJnb0NEIG1hdGNoZXMiLCJ4IjoieCIsImlzcyI6ImFyZ29jZCJ9.kHldeGEECY3basc-aTT-3eQvellg8T02h8M02M3v3c0
 
 - rule.description: ArgoCD JWT
-  rule.id: c42a367392fc3aadefbf9caa4de4582a790b8746ed72e6e97fca6f962502597a
+  rule.id: nPY_Rcj4gzY
   location.path: general-test
   match: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJsZWFrdGsiLCJub3RlIjoiZm9yIHRlc3RpbmcgQXJnb0NEIG1hdGNoZXMiLCJ4IjoieHh4IiwiaXNzIjoiYXJnb2NkIn0.VJXhFqDs4FGGHPznFO8ZkwiteXL5sLMeUaGGEXS02h4
   secret: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJsZWFrdGsiLCJub3RlIjoiZm9yIHRlc3RpbmcgQXJnb0NEIG1hdGNoZXMiLCJ4IjoieHh4IiwiaXNzIjoiYXJnb2NkIn0.VJXhFqDs4FGGHPznFO8ZkwiteXL5sLMeUaGGEXS02h4
 
 - rule.description: ArgoCD JWT
-  rule.id: c42a367392fc3aadefbf9caa4de4582a790b8746ed72e6e97fca6f962502597a
+  rule.id: nPY_Rcj4gzY
   location.path: general-test
   match: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJsZWFrdGsiLCJub3RlIjoiZm9yIHRlc3RpbmcgQXJnb0NEIG1hdGNoZXMiLCJpc3MiOiJhcmdvY2QifQ.IMSC5Gl6CavUctOoILAcHN4YAsH3ihQz7l6mDobClXw
   secret: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJsZWFrdGsiLCJub3RlIjoiZm9yIHRlc3RpbmcgQXJnb0NEIG1hdGNoZXMiLCJpc3MiOiJhcmdvY2QifQ.IMSC5Gl6CavUctOoILAcHN4YAsH3ihQz7l6mDobClXw
@@ -183,7 +183,7 @@
 #
 
 - rule.description: Auth0 JWT
-  rule.id: 4467285558ee1cc8f1fd91a98bb0109432c4e7684851a2a616ba20ec8154fd9b
+  rule.id: o3-Wm5oL1D4
   location.path: auth0/valid/auth0.jwt
   match: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaXNzIjoiaHR0cHM6Ly9mb28uYXV0aDAuY29tLyIsImlhdCI6MTUxNjIzOTAyMn0.q2tBN5Vj6jI7QY642T_S8-TQ0H4VKGOJovDtkaRXWxQ
   secret: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaXNzIjoiaHR0cHM6Ly9mb28uYXV0aDAuY29tLyIsImlhdCI6MTUxNjIzOTAyMn0.q2tBN5Vj6jI7QY642T_S8-TQ0H4VKGOJovDtkaRXWxQ
@@ -193,7 +193,7 @@
 #
 
 - rule.description: Auth0 OAuth Client Secret
-  rule.id: d6cdf13aa9b7b02a7f259b6f116bcbe24e4a30a01f566a418211c6e02e39fd79
+  rule.id: -bDTAD8YMJg
   location.path: auth0/valid/oauth-config.yaml
   match: |-
     auth0.com
@@ -202,7 +202,7 @@
   secret: ft2bEnamwiIbpIP_zkeChaoaMRlb5X3gq_DZwQZZOY-_GuheOAGQZ1q6uK3V_FnP
 
 - rule.description: Auth0 OAuth Client Secret
-  rule.id: d6cdf13aa9b7b02a7f259b6f116bcbe24e4a30a01f566a418211c6e02e39fd79
+  rule.id: -bDTAD8YMJg
   location.path: auth0/valid/oauth-env.sh
   match: |-
     AUTH0_DOMAIN="some-domain.auth0.com"
@@ -215,31 +215,31 @@
 #
 
 - rule.description: Authorization Header
-  rule.id: 193ff72dae32b07dfa5773a929ba5d3f5bc166a8c4b5c10aa266c3fc613e545a
+  rule.id: QqS4RvI6Zmg
   location.path: generic/valid/authorization-header
   match: '''Authorization: Bearer arQiwF9k82w8bHeWR-ZM60vh1m5A5FKAIHoV2KWogw6rDM530Z0ZiCOxuJcb77EOIzBDTiyHqIsdyHhXjeXd_g'
   secret: arQiwF9k82w8bHeWR-ZM60vh1m5A5FKAIHoV2KWogw6rDM530Z0ZiCOxuJcb77EOIzBDTiyHqIsdyHhXjeXd_g
 
 - rule.description: Authorization Header
-  rule.id: 193ff72dae32b07dfa5773a929ba5d3f5bc166a8c4b5c10aa266c3fc613e545a
+  rule.id: QqS4RvI6Zmg
   location.path: generic/valid/authorization-header-with-basic-auth
   match: '''Authorization: Basic YWRtaW46STdSTnVJaDV3S3FLbTRaZzk3UFBrQThCNGRWVU1qUkJLY1NCbkVCdTBvNA=='
   secret: YWRtaW46STdSTnVJaDV3S3FLbTRaZzk3UFBrQThCNGRWVU1qUkJLY1NCbkVCdTBvNA==
 
 - rule.description: Authorization Header
-  rule.id: 193ff72dae32b07dfa5773a929ba5d3f5bc166a8c4b5c10aa266c3fc613e545a
+  rule.id: QqS4RvI6Zmg
   location.path: generic/valid/authorization-header-with-basic-auth
   match: '''Authorization: Basic admin:I7RNuIh5wKqKm4Zg97PPkA8B4dVUMjRBKcSBnEBu0o4'
   secret: admin:I7RNuIh5wKqKm4Zg97PPkA8B4dVUMjRBKcSBnEBu0o4
 
 - rule.description: Authorization Header
-  rule.id: 193ff72dae32b07dfa5773a929ba5d3f5bc166a8c4b5c10aa266c3fc613e545a
+  rule.id: QqS4RvI6Zmg
   location.path: generic/valid/authorization-header-with-flat-token
   match: '''Authorization: xrQiwF9k82w8bHeWR-ZM60vh1m5A5FKAIHoV2KWogw6rDM530Z0ZiCOxuJcb77EOIzBDTiyHqIsdyHhXjeXd_g'
   secret: xrQiwF9k82w8bHeWR-ZM60vh1m5A5FKAIHoV2KWogw6rDM530Z0ZiCOxuJcb77EOIzBDTiyHqIsdyHhXjeXd_g
 
 - rule.description: Authorization Header
-  rule.id: 193ff72dae32b07dfa5773a929ba5d3f5bc166a8c4b5c10aa266c3fc613e545a
+  rule.id: QqS4RvI6Zmg
   location.path: mailchimp
   match: '"Authorization: Bearer ae54fcc23ade65fa404a65e78c56f898-us1'
   secret: ae54fcc23ade65fa404a65e78c56f898-us1
@@ -249,13 +249,13 @@
 #
 
 - rule.description: Azure Active Directory Client Secret
-  rule.id: 2c2cec078f547f39f2951ce131d2a18dcb5d9feb5d031679212b79f0d3cb5162
+  rule.id: zl044yuux24
   location.path: azure/valid/ad-keys.env
   match: =3~K7Q~yxHSpLEt8z5YsP~pMcmAMOPlwxG4JcXbT
   secret: 3~K7Q~yxHSpLEt8z5YsP~pMcmAMOPlwxG4JcXbT
 
 - rule.description: Azure Active Directory Client Secret
-  rule.id: 2c2cec078f547f39f2951ce131d2a18dcb5d9feb5d031679212b79f0d3cb5162
+  rule.id: zl044yuux24
   location.path: azure/valid/ad-keys.properties
   match: =3~K7Q~yxHSpLEt8z5YsP~pMcmAMOPlwxG4JcXbT
   secret: 3~K7Q~yxHSpLEt8z5YsP~pMcmAMOPlwxG4JcXbT
@@ -265,7 +265,7 @@
 #
 
 - rule.description: Base64 Encoded AWS Secret Access Key
-  rule.id: 2eefe8aec9ce2ef59bd4e258d84ed17a0303dee93e6dffb49002acc877d33ee1
+  rule.id: d01DtP9iA8I
   location.path: aws/valid/b64-encoded-k8s-secret-with-aws-creds
   match: YXBpVmVyc2lvbjogdjEKZGF0YToKICBhd3NfYWNjZXNzX2tleV9pZDogUVV0SlFWaFlXRmhZV0ZoWVdGaFlXRmhZV0ZnPQogIGF3c19zZWNyZXRfYWNjZXNzX2tleTogVURSc1JqUlFlalprWjFwaFlsRjBLM0JrVWxCUUsyczNkbk01Um1GMFFWWnVkR2hZU3pkakNnPT0Ka2luZDogU2VjcmV0Cm1ldGFkYXRhOgogIG5hbWVzcGFjZTogZXhhbXBsZQogIG5hbWU6IGF3cy1jcmVkcwo=
   secret: YXBpVmVyc2lvbjogdjEKZGF0YToKICBhd3NfYWNjZXNzX2tleV9pZDogUVV0SlFWaFlXRmhZV0ZoWVdGaFlXRmhZV0ZnPQogIGF3c19zZWNyZXRfYWNjZXNzX2tleTogVURSc1JqUlFlalprWjFwaFlsRjBLM0JrVWxCUUsyczNkbk01Um1GMFFWWnVkR2hZU3pkakNnPT0Ka2luZDogU2VjcmV0Cm1ldGFkYXRhOgogIG5hbWVzcGFjZTogZXhhbXBsZQogIG5hbWU6IGF3cy1jcmVkcwo=
@@ -275,13 +275,13 @@
 #
 
 - rule.description: Base64 Encoded OpenSSH Private Key
-  rule.id: fe1cc0c882af5eac1fc66d4d357a6a9c508586fdb7d01f61c53f7ad926ccaa85
+  rule.id: RVee3wT2Z4I
   location.path: pki/valid/b64-encoded-openssh-private-key
   match: LS0tLS1CRUdJTiBPUEVOU1NIIFBSSVZBVEUgS0VZLS0tLS0KYjNCbGJuTnphQzFyWlhrdGRqRUFBQUFBQ21GbGN6STFOaTFqZEhJQUFBQUdZbU55ZVhCMEFBQUFHQUFBQUJEZkFXZzdPVQpPRE96b3hBWVUwcWVYRUFBQUFFQUFBQUFFQUFBQXpBQUFBQzNOemFDMWxaREkxTlRFNUFBQUFJQjJwY1dha09PR0xVaCswCk5id2RXTzh6UGk2YzR5QlRKL0pxWEMzZ2M4NWNBQUFBb1B0Vm1NS1pqOEdHNUpNa2ZNekxKeVFZcmNLVjBSODN6WTNGSEUKS2swcnRjdC9PMDlnQ0xrb2h0VGJhbzloWXBSaXljSTRKcXU1bUIrekxpVXQ5Q2VnakdnMm05VUxrOFdzOTRCcXhWQVpSTwpzclJnV2pVOWljTlFBbkkwYk5EWnJUWUI4WEJTQ2lYdkc3V3pmTkRTc3M5UVQyY0FEQVpFZnlhMDFxb0dYOS9WOExNU1NOClUwdzlmTHdsN2FNc0lkRmdwdllqeXFvSmc3VVcweHZBdjlaNGc9Ci0tLS0tRU5EIE9QRU5TU0ggUFJJVkFURSBLRVktLS0tLQo=
   secret: LS0tLS1CRUdJTiBPUEVOU1NIIFBSSVZBVEUgS0VZLS0tLS0KYjNCbGJuTnphQzFyWlhrdGRqRUFBQUFBQ21GbGN6STFOaTFqZEhJQUFBQUdZbU55ZVhCMEFBQUFHQUFBQUJEZkFXZzdPVQpPRE96b3hBWVUwcWVYRUFBQUFFQUFBQUFFQUFBQXpBQUFBQzNOemFDMWxaREkxTlRFNUFBQUFJQjJwY1dha09PR0xVaCswCk5id2RXTzh6UGk2YzR5QlRKL0pxWEMzZ2M4NWNBQUFBb1B0Vm1NS1pqOEdHNUpNa2ZNekxKeVFZcmNLVjBSODN6WTNGSEUKS2swcnRjdC9PMDlnQ0xrb2h0VGJhbzloWXBSaXljSTRKcXU1bUIrekxpVXQ5Q2VnakdnMm05VUxrOFdzOTRCcXhWQVpSTwpzclJnV2pVOWljTlFBbkkwYk5EWnJUWUI4WEJTQ2lYdkc3V3pmTkRTc3M5UVQyY0FEQVpFZnlhMDFxb0dYOS9WOExNU1NOClUwdzlmTHdsN2FNc0lkRmdwdllqeXFvSmc3VVcweHZBdjlaNGc9Ci0tLS0tRU5EIE9QRU5TU0ggUFJJVkFURSBLRVktLS0tLQo=
 
 - rule.description: Base64 Encoded OpenSSH Private Key
-  rule.id: fe1cc0c882af5eac1fc66d4d357a6a9c508586fdb7d01f61c53f7ad926ccaa85
+  rule.id: RVee3wT2Z4I
   location.path: pki/valid/multi-line-b64-encoded-openssh-private-key
   match: |-
     LS0tLS1CRUdJTiBPUEVOU1NIIFBSSVZBVEUgS0VZLS0tLS0KYjNCbGJuTnphQzFyWlhrdGRqRUFB
@@ -309,13 +309,13 @@
 #
 
 - rule.description: Container Registry Authentication
-  rule.id: 3161082b147ad645b6d3637f68edcfa87949a79b45004efeef036e2cb7a0edfe
+  rule.id: gpfGmO3HH64
   location.path: containers/valid/container-auth.1.json
   match: '"auths":{"cloud.openshift.com":{"auth":"WqQm513Gn8MFE9h8LyozXt5n2tg7_5e55oEFG3Ll6LMmZL0cH0qfOaaSgYb0ymxDMHqeoMIKfvgL7Ho5fqOzpg","email":"user@leaktk.org"},"quay.io":{"auth":"jj8AYnG-gSfo-v_JwtBSWCoVXi3q5-PEuuPkA2sWVeZwefdNrjBOvsdofE49hJNSDlu4sbFIUyXzKfGMTRgvxw","email":"user@leaktk.org"},"registry.connect.redhat.com":{"auth":"vPrPu21bd8cKc8bEa6aNYsgEIZmueurPRCqHwRL6VrbVuCWZw_G0qX34oYbNEd2rFmkVsn98slBoQjl4WnPVmA","email":"user@leaktk.org"},"registry.redhat.io":{"auth":"SxeHVLwn_0k9FS2WSbKvgnODlYGygS-kOdTIqIp5-3sZLorIeloe4iKXfu0t7TdlZ_hoYNgGf0lFGnTzEMSYnw","email":"user@leaktk.org"}}'
   secret: '"auths":{"cloud.openshift.com":{"auth":"WqQm513Gn8MFE9h8LyozXt5n2tg7_5e55oEFG3Ll6LMmZL0cH0qfOaaSgYb0ymxDMHqeoMIKfvgL7Ho5fqOzpg","email":"user@leaktk.org"},"quay.io":{"auth":"jj8AYnG-gSfo-v_JwtBSWCoVXi3q5-PEuuPkA2sWVeZwefdNrjBOvsdofE49hJNSDlu4sbFIUyXzKfGMTRgvxw","email":"user@leaktk.org"},"registry.connect.redhat.com":{"auth":"vPrPu21bd8cKc8bEa6aNYsgEIZmueurPRCqHwRL6VrbVuCWZw_G0qX34oYbNEd2rFmkVsn98slBoQjl4WnPVmA","email":"user@leaktk.org"},"registry.redhat.io":{"auth":"SxeHVLwn_0k9FS2WSbKvgnODlYGygS-kOdTIqIp5-3sZLorIeloe4iKXfu0t7TdlZ_hoYNgGf0lFGnTzEMSYnw","email":"user@leaktk.org"}}'
 
 - rule.description: Container Registry Authentication
-  rule.id: 3161082b147ad645b6d3637f68edcfa87949a79b45004efeef036e2cb7a0edfe
+  rule.id: gpfGmO3HH64
   location.path: containers/valid/container-auth.2.json
   match: |-
     "auths": {
@@ -345,13 +345,13 @@
       }
 
 - rule.description: Container Registry Authentication
-  rule.id: 3161082b147ad645b6d3637f68edcfa87949a79b45004efeef036e2cb7a0edfe
+  rule.id: gpfGmO3HH64
   location.path: containers/valid/container-auth.3.json
   match: \"auths\":{\"cloud.openshift.com\":{\"auth\":\"WqQm513Gn8MFE9h8LyozXt5n2tg7_5e55oEFG3Ll6LMmZL0cH0qfOaaSgYb0ymxDMHqeoMIKfvgL7Ho5fqOzpg\",\"email\":\"user@leaktk.org\"},\"quay.io\":{\"auth\":\"jj8AYnG-gSfo-v_JwtBSWCoVXi3q5-PEuuPkA2sWVeZwefdNrjBOvsdofE49hJNSDlu4sbFIUyXzKfGMTRgvxw\",\"email\":\"user@leaktk.org\"},\"registry.connect.redhat.com\":{\"auth\":\"vPrPu21bd8cKc8bEa6aNYsgEIZmueurPRCqHwRL6VrbVuCWZw_G0qX34oYbNEd2rFmkVsn98slBoQjl4WnPVmA\",\"email\":\"user@leaktk.org\"},\"registry.redhat.io\":{\"auth\":\"SxeHVLwn_0k9FS2WSbKvgnODlYGygS-kOdTIqIp5-3sZLorIeloe4iKXfu0t7TdlZ_hoYNgGf0lFGnTzEMSYnw\",\"email\":\"user@leaktk.org\"}}
   secret: \"auths\":{\"cloud.openshift.com\":{\"auth\":\"WqQm513Gn8MFE9h8LyozXt5n2tg7_5e55oEFG3Ll6LMmZL0cH0qfOaaSgYb0ymxDMHqeoMIKfvgL7Ho5fqOzpg\",\"email\":\"user@leaktk.org\"},\"quay.io\":{\"auth\":\"jj8AYnG-gSfo-v_JwtBSWCoVXi3q5-PEuuPkA2sWVeZwefdNrjBOvsdofE49hJNSDlu4sbFIUyXzKfGMTRgvxw\",\"email\":\"user@leaktk.org\"},\"registry.connect.redhat.com\":{\"auth\":\"vPrPu21bd8cKc8bEa6aNYsgEIZmueurPRCqHwRL6VrbVuCWZw_G0qX34oYbNEd2rFmkVsn98slBoQjl4WnPVmA\",\"email\":\"user@leaktk.org\"},\"registry.redhat.io\":{\"auth\":\"SxeHVLwn_0k9FS2WSbKvgnODlYGygS-kOdTIqIp5-3sZLorIeloe4iKXfu0t7TdlZ_hoYNgGf0lFGnTzEMSYnw\",\"email\":\"user@leaktk.org\"}}
 
 - rule.description: Container Registry Authentication
-  rule.id: 3161082b147ad645b6d3637f68edcfa87949a79b45004efeef036e2cb7a0edfe
+  rule.id: gpfGmO3HH64
   location.path: containers/valid/container-auth.4.json
   match: \\\"auths\\\":{\\\"cloud.openshift.com\\\":{\\\"auth\\\":\\\"WqQm513Gn8MFE9h8LyozXt5n2tg7_5e55oEFG3Ll6LMmZL0cH0qfOaaSgYb0ymxDMHqeoMIKfvgL7Ho5fqOzpg\\\",\\\"email\\\":\\\"user@leaktk.org\\\"},\\\"quay.io\\\":{\\\"auth\\\":\\\"jj8AYnG-gSfo-v_JwtBSWCoVXi3q5-PEuuPkA2sWVeZwefdNrjBOvsdofE49hJNSDlu4sbFIUyXzKfGMTRgvxw\\\",\\\"email\\\":\\\"user@leaktk.org\\\"},\\\"registry.connect.redhat.com\\\":{\\\"auth\\\":\\\"vPrPu21bd8cKc8bEa6aNYsgEIZmueurPRCqHwRL6VrbVuCWZw_G0qX34oYbNEd2rFmkVsn98slBoQjl4WnPVmA\\\",\\\"email\\\":\\\"user@leaktk.org\\\"},\\\"registry.redhat.io\\\":{\\\"auth\\\":\\\"SxeHVLwn_0k9FS2WSbKvgnODlYGygS-kOdTIqIp5-3sZLorIeloe4iKXfu0t7TdlZ_hoYNgGf0lFGnTzEMSYnw\\\",\\\"email\\\":\\\"user@leaktk.org\\\"}}
   secret: \\\"auths\\\":{\\\"cloud.openshift.com\\\":{\\\"auth\\\":\\\"WqQm513Gn8MFE9h8LyozXt5n2tg7_5e55oEFG3Ll6LMmZL0cH0qfOaaSgYb0ymxDMHqeoMIKfvgL7Ho5fqOzpg\\\",\\\"email\\\":\\\"user@leaktk.org\\\"},\\\"quay.io\\\":{\\\"auth\\\":\\\"jj8AYnG-gSfo-v_JwtBSWCoVXi3q5-PEuuPkA2sWVeZwefdNrjBOvsdofE49hJNSDlu4sbFIUyXzKfGMTRgvxw\\\",\\\"email\\\":\\\"user@leaktk.org\\\"},\\\"registry.connect.redhat.com\\\":{\\\"auth\\\":\\\"vPrPu21bd8cKc8bEa6aNYsgEIZmueurPRCqHwRL6VrbVuCWZw_G0qX34oYbNEd2rFmkVsn98slBoQjl4WnPVmA\\\",\\\"email\\\":\\\"user@leaktk.org\\\"},\\\"registry.redhat.io\\\":{\\\"auth\\\":\\\"SxeHVLwn_0k9FS2WSbKvgnODlYGygS-kOdTIqIp5-3sZLorIeloe4iKXfu0t7TdlZ_hoYNgGf0lFGnTzEMSYnw\\\",\\\"email\\\":\\\"user@leaktk.org\\\"}}
@@ -361,13 +361,13 @@
 #
 
 - rule.description: Dropbox Refresh Token
-  rule.id: 6cb7e194180b90306cc5952b4e74698177970f9a3f121339476b9891805820ca
+  rule.id: qUN8svLm9sk
   location.path: dropbox/valid/legacy-long-lived-access-token
   match: '"7rBynGOob1cAAAAAAAAAAe72L3T6rQK5ImB5a06ijnwRG9IdeTxvsqdZNAIxq8pZ"'
   secret: 7rBynGOob1cAAAAAAAAAAe72L3T6rQK5ImB5a06ijnwRG9IdeTxvsqdZNAIxq8pZ
 
 - rule.description: Dropbox Refresh Token
-  rule.id: 6cb7e194180b90306cc5952b4e74698177970f9a3f121339476b9891805820ca
+  rule.id: qUN8svLm9sk
   location.path: dropbox/valid/short-lived-offline-access-token
   match: '"nBiM85CZALsAAAAAAAAAAQXHBoNpNutK4ngsXHsqW4iGz9tisb3JyjGqikMJIYbd"'
   secret: nBiM85CZALsAAAAAAAAAAQXHBoNpNutK4ngsXHsqW4iGz9tisb3JyjGqikMJIYbd
@@ -377,13 +377,13 @@
 #
 
 - rule.description: Dropbox Short-Lived Access Token
-  rule.id: eebe1f7351c8edb9aadc710be96072b4cf592aeaefe63a425fed3db21f04451f
+  rule.id: vtSSaD-DcYo
   location.path: dropbox/valid/oidc-request
   match: '"sl.AbX9y6Fe3AuH5o66-gmJpR032jwAwQPIVVzWXZNkdzcYT02akC2de219dZi6gxYPVnYPrpvISRSf9lxKWJzYLjtMPH-d9fo_0gXex7X37VIvpty4-G8f4-WX45AcEPfRnJJDwzv-"'
   secret: sl.AbX9y6Fe3AuH5o66-gmJpR032jwAwQPIVVzWXZNkdzcYT02akC2de219dZi6gxYPVnYPrpvISRSf9lxKWJzYLjtMPH-d9fo_0gXex7X37VIvpty4-G8f4-WX45AcEPfRnJJDwzv-
 
 - rule.description: Dropbox Short-Lived Access Token
-  rule.id: eebe1f7351c8edb9aadc710be96072b4cf592aeaefe63a425fed3db21f04451f
+  rule.id: vtSSaD-DcYo
   location.path: dropbox/valid/short-lived-token
   match: '"sl.AbX9y6Fe3AuH5o66-gmJpR032jwAwQPIVVzWXZNkdzcYT02akC2de219dZi6gxYPVnYPrpvISRSf9lxKWJzYLjtMPH-d9fo_0gXex7X37VIvpty4-G8f4-WX45AcEPfRnJJDwzv-"'
   secret: sl.AbX9y6Fe3AuH5o66-gmJpR032jwAwQPIVVzWXZNkdzcYT02akC2de219dZi6gxYPVnYPrpvISRSf9lxKWJzYLjtMPH-d9fo_0gXex7X37VIvpty4-G8f4-WX45AcEPfRnJJDwzv-
@@ -393,7 +393,7 @@
 #
 
 - rule.description: Dropbox Short-Lived Offline Access Token
-  rule.id: 9e617f6025412a3b8d7dcd12e6242416c32c1524845239892612230b0ca227d5
+  rule.id: tvqG--ROt7U
   location.path: dropbox/valid/short-lived-offline-access-token
   match: '"sl.u.AbX9y6Fe3AuH5o66-gmJpR032jwAwQPIVVzWXZNkdzcYT02akC2de219dZi6gxYPVnYPrpvISRSf9lxKWJzYLjtMPH-d9fo_0gXex7X37VIvpty4-G8f4-WX45AcEPfRnJJDwzv-"'
   secret: sl.u.AbX9y6Fe3AuH5o66-gmJpR032jwAwQPIVVzWXZNkdzcYT02akC2de219dZi6gxYPVnYPrpvISRSf9lxKWJzYLjtMPH-d9fo_0gXex7X37VIvpty4-G8f4-WX45AcEPfRnJJDwzv-
@@ -403,7 +403,7 @@
 #
 
 - rule.description: Dynatrace Token
-  rule.id: e0e0ef11399b51b8efa864542979614bd1bb2288f3cb8bd2aa786e1a4aee9e79
+  rule.id: me-TlU0uKS8
   location.path: dynatrace-token
   match: dt0s01.ST2EY72KQINMH574WMNVI7YN.G3DFPBEJYMODIDAEX454M7YWBUVEFOWKPRVMWFASS64NFH52PX6BNDVFFM573RZM
   secret: dt0s01.ST2EY72KQINMH574WMNVI7YN.G3DFPBEJYMODIDAEX454M7YWBUVEFOWKPRVMWFASS64NFH52PX6BNDVFFM573RZM
@@ -413,13 +413,13 @@
 #
 
 - rule.description: Facebook Access Token
-  rule.id: fc611155cdab32cb4ac3edf51045a9f73e066eee77c2c8d9771b29e7849212c0
+  rule.id: bzBQF-LMlZU
   location.path: semgrep-rules-examples/detected-facebook-access-token.txt
   match: EAACEdEose0cBAIWHqjHI5o2auPWv3lPP3zNYuWWpjMrSaIFxbQeve3lsLOcas5k8GhC5HgOXnbF3rXRTczOpsbNjJW0CQL8LcQEMhZAWAJzI0AzmLriWuuZByFAia5aFl0Q4Xv4u2QVoAdH0mcJbZAHRpyJKIAyDKUEBzz0GgZDZD
   secret: EAACEdEose0cBAIWHqjHI5o2auPWv3lPP3zNYuWWpjMrSaIFxbQeve3lsLOcas5k8GhC5HgOXnbF3rXRTczOpsbNjJW0CQL8LcQEMhZAWAJzI0AzmLriWuuZByFAia5aFl0Q4Xv4u2QVoAdH0mcJbZAHRpyJKIAyDKUEBzz0GgZDZD
 
 - rule.description: Facebook Access Token
-  rule.id: fc611155cdab32cb4ac3edf51045a9f73e066eee77c2c8d9771b29e7849212c0
+  rule.id: bzBQF-LMlZU
   location.path: semgrep-rules-examples/detected-facebook-access-token.txt
   match: EAACEdEose0cBAMF99BFdceBHS5UcaEPIDbhKT1nbE0DaulfIS8ZCJTHrkD6IxkfKZCObCHzUsHcdhBISYuv7L4oiylZCmNztRy6s9KBgmZBYbJxZBBk1Csjl8PXFnZA3rt5WwZB7dZCB9M04a6FI7XwCFXfNV4ZB76y6SjltVc4AP4gZDZD
   secret: EAACEdEose0cBAMF99BFdceBHS5UcaEPIDbhKT1nbE0DaulfIS8ZCJTHrkD6IxkfKZCObCHzUsHcdhBISYuv7L4oiylZCmNztRy6s9KBgmZBYbJxZBBk1Csjl8PXFnZA3rt5WwZB7dZCB9M04a6FI7XwCFXfNV4ZB76y6SjltVc4AP4gZDZD
@@ -429,631 +429,631 @@
 #
 
 - rule.description: Generic Secret
-  rule.id: dd85b788ea6c12f4968c38091c2576ff17ce23565d8d14f2a3b34d44dccddec2
+  rule.id: rnWF160pWNg
   location.path: auth0/valid/oauth-config.yaml
   match: 'secret: ft2bEnamwiIbpIP_zkeChaoaMRlb5X3gq_DZwQZZOY-_GuheOAGQZ1q6uK3V_FnP'
   secret: ft2bEnamwiIbpIP_zkeChaoaMRlb5X3gq_DZwQZZOY-_GuheOAGQZ1q6uK3V_FnP
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: auth0/valid/oauth-env.sh
   match: SECRET="WtiyWPt2NEYSqyPiM4_ej0y92Ca55KZurnvGrNccMAhh1GcgNJTEnfqDWmmP1mlV"
   secret: WtiyWPt2NEYSqyPiM4_ej0y92Ca55KZurnvGrNccMAhh1GcgNJTEnfqDWmmP1mlV
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: dropbox/valid/legacy-long-lived-access-token
   match: 'token": "7rBynGOob1cAAAAAAAAAAe72L3T6rQK5ImB5a06ijnwRG9IdeTxvsqdZNAIxq8pZ"'
   secret: 7rBynGOob1cAAAAAAAAAAe72L3T6rQK5ImB5a06ijnwRG9IdeTxvsqdZNAIxq8pZ
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: dropbox/valid/oidc-request
   match: 'token": "eyJhbGciOiJSUzI1NiIsImtpZCI6IkRUVXpsY3Nw"'
   secret: eyJhbGciOiJSUzI1NiIsImtpZCI6IkRUVXpsY3Nw
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: dropbox/valid/oidc-request
   match: 'token": "sl.AbX9y6Fe3AuH5o66-gmJpR032jwAwQPIVVzWXZNkdzcYT02akC2de219dZi6gxYPVnYPrpvISRSf9lxKWJzYLjtMPH-d9fo_0gXex7X37VIvpty4-G8f4-WX45AcEPfRnJJDwzv-"'
   secret: sl.AbX9y6Fe3AuH5o66-gmJpR032jwAwQPIVVzWXZNkdzcYT02akC2de219dZi6gxYPVnYPrpvISRSf9lxKWJzYLjtMPH-d9fo_0gXex7X37VIvpty4-G8f4-WX45AcEPfRnJJDwzv-
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: dropbox/valid/short-lived-offline-access-token
   match: 'token": "nBiM85CZALsAAAAAAAAAAQXHBoNpNutK4ngsXHsqW4iGz9tisb3JyjGqikMJIYbd"'
   secret: nBiM85CZALsAAAAAAAAAAQXHBoNpNutK4ngsXHsqW4iGz9tisb3JyjGqikMJIYbd
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: dropbox/valid/short-lived-offline-access-token
   match: 'token": "sl.u.AbX9y6Fe3AuH5o66-gmJpR032jwAwQPIVVzWXZNkdzcYT02akC2de219dZi6gxYPVnYPrpvISRSf9lxKWJzYLjtMPH-d9fo_0gXex7X37VIvpty4-G8f4-WX45AcEPfRnJJDwzv-"'
   secret: sl.u.AbX9y6Fe3AuH5o66-gmJpR032jwAwQPIVVzWXZNkdzcYT02akC2de219dZi6gxYPVnYPrpvISRSf9lxKWJzYLjtMPH-d9fo_0gXex7X37VIvpty4-G8f4-WX45AcEPfRnJJDwzv-
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: dropbox/valid/short-lived-token
   match: 'token": "sl.AbX9y6Fe3AuH5o66-gmJpR032jwAwQPIVVzWXZNkdzcYT02akC2de219dZi6gxYPVnYPrpvISRSf9lxKWJzYLjtMPH-d9fo_0gXex7X37VIvpty4-G8f4-WX45AcEPfRnJJDwzv-"'
   secret: sl.AbX9y6Fe3AuH5o66-gmJpR032jwAwQPIVVzWXZNkdzcYT02akC2de219dZi6gxYPVnYPrpvISRSf9lxKWJzYLjtMPH-d9fo_0gXex7X37VIvpty4-G8f4-WX45AcEPfRnJJDwzv-
 
 - rule.description: Generic Secret
-  rule.id: 08147f6d4edc040aa8cc8d9313221aad0f0826de534f250b9987e6357bf8ae44
+  rule.id: mC5kOxQ6kn4
   location.path: foo.clientSecret
   match: 0dyKPI359SlFVIEKoL9qakPlP5xuQDxZ9aGP45xAc5NI
   secret: 0dyKPI359SlFVIEKoL9qakPlP5xuQDxZ9aGP45xAc5NI
 
 - rule.description: Generic Secret
-  rule.id: 08147f6d4edc040aa8cc8d9313221aad0f0826de534f250b9987e6357bf8ae44
+  rule.id: mC5kOxQ6kn4
   location.path: foo.password
   match: 1dyKPI359SlFVIEKoL9qakPlP5xuQDxZ9aGP45xAc5NI
   secret: 1dyKPI359SlFVIEKoL9qakPlP5xuQDxZ9aGP45xAc5NI
 
 - rule.description: Generic Secret
-  rule.id: 08147f6d4edc040aa8cc8d9313221aad0f0826de534f250b9987e6357bf8ae44
+  rule.id: mC5kOxQ6kn4
   location.path: foo.sometoken
   match: 2dyKPI359SlFVIEKoL9qakPlP5xuQDxZ9aGP45xAc5NI
   secret: 2dyKPI359SlFVIEKoL9qakPlP5xuQDxZ9aGP45xAc5NI
 
 - rule.description: Generic Secret
-  rule.id: a8d78f8de4bad0b519a8a14b625bc6d8ae3055bd8d8de6fc5c4b0b31bac4249e
+  rule.id: eCOHX_SKGzA
   location.path: general-test
   match: <FooPassword id="new" >$A3ae68d9f8ccfc898ee2555a5f8f228b9</FooPassword>
   secret: $A3ae68d9f8ccfc898ee2555a5f8f228b9
 
 - rule.description: Generic Secret
-  rule.id: a8d78f8de4bad0b519a8a14b625bc6d8ae3055bd8d8de6fc5c4b0b31bac4249e
+  rule.id: eCOHX_SKGzA
   location.path: general-test
   match: <FooSecret id="new" >$A3ae68d9f8ccfc898ee2555a5f8f228b9</FooSecret>
   secret: $A3ae68d9f8ccfc898ee2555a5f8f228b9
 
 - rule.description: Generic Secret
-  rule.id: a8d78f8de4bad0b519a8a14b625bc6d8ae3055bd8d8de6fc5c4b0b31bac4249e
+  rule.id: eCOHX_SKGzA
   location.path: general-test
   match: <password>$A3ae68d9f8ccfc898ee2555a5f8f228b9</password>
   secret: $A3ae68d9f8ccfc898ee2555a5f8f228b9
 
 - rule.description: Generic Secret
-  rule.id: a8d78f8de4bad0b519a8a14b625bc6d8ae3055bd8d8de6fc5c4b0b31bac4249e
+  rule.id: eCOHX_SKGzA
   location.path: general-test
   match: <secret>$A3ae68d9f8ccfc898ee2555a5f8f228b9</secret>
   secret: $A3ae68d9f8ccfc898ee2555a5f8f228b9
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: 'SecretAccessKey": "1b3d576ba5a108c3b7374142bfd02992"'
   secret: 1b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: 'SecretAccessKey": "2b3d576ba5a108c3b7374142bfd02992"'
   secret: 2b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: 'SecretAccessKey": "3b3d576ba5a108c3b7374142bfd02992"'
   secret: 3b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: 'SecretAccessKey": "4b3d576ba5a108c3b7374142bfd02992"'
   secret: 4b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: 'SecretAccessKey": "5b3d576ba5a108c3b7374142bfd02992"'
   secret: 5b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: 'SecretAccessKey": "swke6BX0-14v3rYb2Ix32AIfTh9j_H_671dcf8gjpdTbsThiJfxapnAqFs8_kiW4ME-ZPxLmVEgmTxxwlb8Xvw"'
   secret: swke6BX0-14v3rYb2Ix32AIfTh9j_H_671dcf8gjpdTbsThiJfxapnAqFs8_kiW4ME-ZPxLmVEgmTxxwlb8Xvw
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: password = "0b3d576ba5a108c3b7374142bfd02992"
   secret: 0b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: password = "Lol-IKR-those-kids-R-Krazy"
   secret: Lol-IKR-those-kids-R-Krazy
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: password = "RAW(kx#2+c7a)"
   secret: RAW(kx#2+c7a)
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: password = "l0l-1kr-th0se-k1ds-r-kr4zy"
   secret: l0l-1kr-th0se-k1ds-r-kr4zy
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: password = '1b3d576ba5a108c3b7374142bfd02992'
   secret: 1b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: password = '2b3d576ba5a108c3b7374142bfd02992'
   secret: 2b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: password = '3b3d576ba5a108c3b7374142bfd02992'
   secret: 3b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: password = '4b3d576ba5a108c3b7374142bfd02992'
   secret: 4b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: password = '5b3d576ba5a108c3b7374142bfd02992'
   secret: 5b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: password = 'swke6BX0-14v3rYb2Ix32AIfTh9j_H_671dcf8gjpdTbsThiJfxapnAqFs8_kiW4ME-ZPxLmVEgmTxxwlb8Xvw'
   secret: swke6BX0-14v3rYb2Ix32AIfTh9j_H_671dcf8gjpdTbsThiJfxapnAqFs8_kiW4ME-ZPxLmVEgmTxxwlb8Xvw
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: password = 'swke6BX0-14v3rYb2Ix32AIfTh9j_H_671dcf8gjpdTbsThiJfxapnAqFs8_kiW4ME-ZPxLmVEgmTxxwlb8Xvw'
   secret: swke6BX0-14v3rYb2Ix32AIfTh9j_H_671dcf8gjpdTbsThiJfxapnAqFs8_kiW4ME-ZPxLmVEgmTxxwlb8Xvw
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: 'password": "3ae68d9f8ccfc898ee2555a5f8f228b9"'
   secret: 3ae68d9f8ccfc898ee2555a5f8f228b9
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: password"] = '8bxd576ba5a108c3b7374142bfd02992'
   secret: 8bxd576ba5a108c3b7374142bfd02992
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: secret = "$A0b3d576ba5a108c3b7374142bfd02992"
   secret: $A0b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: secret = "RAW(kx#2+c7a)"
   secret: RAW(kx#2+c7a)
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: 'secret": "$A3ae68d9f8ccfc898ee2555a5f8f228b9"'
   secret: $A3ae68d9f8ccfc898ee2555a5f8f228b9
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: secret'] = "9bxd576ba5a108c3b7374142bfd02993"
   secret: 9bxd576ba5a108c3b7374142bfd02993
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: secret-key = "766a929d93c9ef30ce3d72d6384eb6fa"
   secret: 766a929d93c9ef30ce3d72d6384eb6fa
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: secret= '1b3d576ba5a108c3b7374142bfd02992'
   secret: 1b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: secret= '2b3d576ba5a108c3b7374142bfd02992'
   secret: 2b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: secret= '3b3d576ba5a108c3b7374142bfd02992'
   secret: 3b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: secret= '4b3d576ba5a108c3b7374142bfd02992'
   secret: 4b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: secret= '5b3d576ba5a108c3b7374142bfd02992'
   secret: 5b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: secret= 'swke6BX0-14v3rYb2Ix32AIfTh9j_H_671dcf8gjpdTbsThiJfxapnAqFs8_kiW4ME-ZPxLmVEgmTxxwlb8Xvw'
   secret: swke6BX0-14v3rYb2Ix32AIfTh9j_H_671dcf8gjpdTbsThiJfxapnAqFs8_kiW4ME-ZPxLmVEgmTxxwlb8Xvw
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: secret='/YNvEGXEXY9BS/YNvE:${asdf.YNvEGXEXY9BS}'
   secret: /YNvEGXEXY9BS/YNvE:${asdf.YNvEGXEXY9BS}
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: secret='aOObST8cGSeh3cYNvEGXEXY9BShQx1EtRdfZ=${asdfae}'
   secret: aOObST8cGSeh3cYNvEGXEXY9BShQx1EtRdfZ=${asdfae}
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: 'secret_access_key": "1b3d576ba5a108c3b7374142bfd02992"'
   secret: 1b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: 'secret_access_key": "2b3d576ba5a108c3b7374142bfd02992"'
   secret: 2b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: 'secret_access_key": "3b3d576ba5a108c3b7374142bfd02992"'
   secret: 3b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: 'secret_access_key": "4b3d576ba5a108c3b7374142bfd02992"'
   secret: 4b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: 'secret_access_key": "5b3d576ba5a108c3b7374142bfd02992"'
   secret: 5b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: 'secret_access_key": "swke6BX0-14v3rYb2Ix32AIfTh9j_H_671dcf8gjpdTbsThiJfxapnAqFs8_kiW4ME-ZPxLmVEgmTxxwlb8Xvw"'
   secret: swke6BX0-14v3rYb2Ix32AIfTh9j_H_671dcf8gjpdTbsThiJfxapnAqFs8_kiW4ME-ZPxLmVEgmTxxwlb8Xvw
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: 'secret_accesskey": "1b3d576ba5a108c3b7374142bfd02992"'
   secret: 1b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: 'secret_accesskey": "2b3d576ba5a108c3b7374142bfd02992"'
   secret: 2b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: 'secret_accesskey": "3b3d576ba5a108c3b7374142bfd02992"'
   secret: 3b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: 'secret_accesskey": "4b3d576ba5a108c3b7374142bfd02992"'
   secret: 4b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: 'secret_accesskey": "5b3d576ba5a108c3b7374142bfd02992"'
   secret: 5b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: 'secret_accesskey": "swke6BX0-14v3rYb2Ix32AIfTh9j_H_671dcf8gjpdTbsThiJfxapnAqFs8_kiW4ME-ZPxLmVEgmTxxwlb8Xvw"'
   secret: swke6BX0-14v3rYb2Ix32AIfTh9j_H_671dcf8gjpdTbsThiJfxapnAqFs8_kiW4ME-ZPxLmVEgmTxxwlb8Xvw
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: secret_key = "766a929d93c9ef30ce3d72d6384eb6fa"
   secret: 766a929d93c9ef30ce3d72d6384eb6fa
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: 'secret_key": "1b3d576ba5a108c3b7374142bfd02992"'
   secret: 1b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: 'secret_key": "2b3d576ba5a108c3b7374142bfd02992"'
   secret: 2b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: 'secret_key": "3b3d576ba5a108c3b7374142bfd02992"'
   secret: 3b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: 'secret_key": "4b3d576ba5a108c3b7374142bfd02992"'
   secret: 4b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: 'secret_key": "5b3d576ba5a108c3b7374142bfd02992"'
   secret: 5b3d576ba5a108c3b7374142bfd02992
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: general-test
   match: 'secret_key": "swke6BX0-14v3rYb2Ix32AIfTh9j_H_671dcf8gjpdTbsThiJfxapnAqFs8_kiW4ME-ZPxLmVEgmTxxwlb8Xvw"'
   secret: swke6BX0-14v3rYb2Ix32AIfTh9j_H_671dcf8gjpdTbsThiJfxapnAqFs8_kiW4ME-ZPxLmVEgmTxxwlb8Xvw
 
 - rule.description: Generic Secret
-  rule.id: a8d78f8de4bad0b519a8a14b625bc6d8ae3055bd8d8de6fc5c4b0b31bac4249e
+  rule.id: eCOHX_SKGzA
   location.path: generic/valid/secret-access-key.xml
   match: <SecretAccessKey>e9aA-H81DWuDFboK3MCVa7diQYQchBx4MKQO02CYnRRUH5B1Q6fI-aGqAA-eX9UP7gbMnvsyVvU84xHUwnP7RA</SecretAccessKey>
   secret: e9aA-H81DWuDFboK3MCVa7diQYQchBx4MKQO02CYnRRUH5B1Q6fI-aGqAA-eX9UP7gbMnvsyVvU84xHUwnP7RA
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: generic/valid/secret-in-config
   match: secret="GrWTm5k2jtWy9CeOVbOjlREt-10NmpePFKxv4Fml89YLwn002kF1cy4LQ1cXs9d2PGx37zOUPQk1yViMhhIdHlhw"
   secret: GrWTm5k2jtWy9CeOVbOjlREt-10NmpePFKxv4Fml89YLwn002kF1cy4LQ1cXs9d2PGx37zOUPQk1yViMhhIdHlhw
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: k8s/valid/secret-after-quotes-double.yml
   match: 'password: "S!B\*d$zDsb="'
   secret: S!B\*d$zDsb=
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: k8s/valid/secret-after-quotes-double.yml
   match: 'password: "UyFCXCpkJHpEc2I9"'
   secret: UyFCXCpkJHpEc2I9
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: k8s/valid/secret-after-quotes-single.yml
   match: 'password: ''S!B\*d$zDsb='''
   secret: S!B\*d$zDsb=
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: k8s/valid/secret-after-quotes-single.yml
   match: 'password: ''UyFCXCpkJHpEc2I9'''
   secret: UyFCXCpkJHpEc2I9
 
 - rule.description: Generic Secret
-  rule.id: dd85b788ea6c12f4968c38091c2576ff17ce23565d8d14f2a3b34d44dccddec2
+  rule.id: rnWF160pWNg
   location.path: k8s/valid/secret-after.yaml
   match: 'token: SGV5IG8vIGJhc2U2NCBpcyBub3Qgc2VjdXJlLiAgR28gYmFjayB0byByZWFkaW5nIHRoZSBhcnRpY2xlLg=='
   secret: SGV5IG8vIGJhc2U2NCBpcyBub3Qgc2VjdXJlLiAgR28gYmFjayB0byByZWFkaW5nIHRoZSBhcnRpY2xlLg==
 
 - rule.description: Generic Secret
-  rule.id: dd85b788ea6c12f4968c38091c2576ff17ce23565d8d14f2a3b34d44dccddec2
+  rule.id: rnWF160pWNg
   location.path: k8s/valid/secret-before-comment.yaml
   match: 'password: S!B\*d$zDsb='
   secret: S!B\*d$zDsb=
 
 - rule.description: Generic Secret
-  rule.id: dd85b788ea6c12f4968c38091c2576ff17ce23565d8d14f2a3b34d44dccddec2
+  rule.id: rnWF160pWNg
   location.path: k8s/valid/secret-before-comment.yaml
   match: 'password: UyFCXCpkJHpEc2I9'
   secret: UyFCXCpkJHpEc2I9
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: k8s/valid/secret-stringdata-after-quotes-double.yml
   match: 'PASSWORD: "a765b22179964c53c8a32acccf5dd90d5fc832607bdd14fccaaaa0062adfd"'
   secret: a765b22179964c53c8a32acccf5dd90d5fc832607bdd14fccaaaa0062adfd
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: k8s/valid/secret-stringdata-after-quotes-single.yaml
   match: 'SECRET: ''bafkreicysg23kiwv34eg2d7qweipxwosdo2py4ldv42nbauguluen5v6am'''
   secret: bafkreicysg23kiwv34eg2d7qweipxwosdo2py4ldv42nbauguluen5v6am
 
 - rule.description: Generic Secret
-  rule.id: dd85b788ea6c12f4968c38091c2576ff17ce23565d8d14f2a3b34d44dccddec2
+  rule.id: rnWF160pWNg
   location.path: k8s/valid/secret-stringdata-after.yml
   match: 'Password: JdxWjqhjWLTB7wn9qtNH2TXwW4p'
   secret: JdxWjqhjWLTB7wn9qtNH2TXwW4p
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: k8s/valid/secret-stringdata-before-quotes-double.yml
   match: 'PASSWORD: "a765b22179964c53c8a32acccf5dd90d5fc832607bdd14fccaaaa0062adfd"'
   secret: a765b22179964c53c8a32acccf5dd90d5fc832607bdd14fccaaaa0062adfd
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: k8s/valid/secret-stringdata-before-quotes-single.yaml
   match: 'SECRET: ''bafkreicysg23kiwv34eg2d7qweipxwosdo2py4ldv42nbauguluen5v6am'''
   secret: bafkreicysg23kiwv34eg2d7qweipxwosdo2py4ldv42nbauguluen5v6am
 
 - rule.description: Generic Secret
-  rule.id: dd85b788ea6c12f4968c38091c2576ff17ce23565d8d14f2a3b34d44dccddec2
+  rule.id: rnWF160pWNg
   location.path: k8s/valid/secret-stringdata-before.yml
   match: 'Password: JdxWjqhjWLTB7wn9qtNH2TXwW4p'
   secret: JdxWjqhjWLTB7wn9qtNH2TXwW4p
 
 - rule.description: Generic Secret
-  rule.id: a8d78f8de4bad0b519a8a14b625bc6d8ae3055bd8d8de6fc5c4b0b31bac4249e
+  rule.id: eCOHX_SKGzA
   location.path: maven/valid/settings-proxy-password.xml
   match: <password>rr84lr6WKq73PDKhXJJOXFVggzj4</password>
   secret: rr84lr6WKq73PDKhXJJOXFVggzj4
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: semgrep-rules-examples/detected-google-oauth-access-token.txt
   match: 'token" : "ya29.AHES67zeEn-RDg9CA5gGKMLKuG4uVB7W4O4WjNr-NBfY6Dtad4vbIZ"'
   secret: ya29.AHES67zeEn-RDg9CA5gGKMLKuG4uVB7W4O4WjNr-NBfY6Dtad4vbIZ
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: settings.py
   match: SECRET_KEY = "zeu#xlk35rk7$b0o_hg7bfr@602da3b6f339dbe9a1054228a74edd6b"
   secret: zeu#xlk35rk7$b0o_hg7bfr@602da3b6f339dbe9a1054228a74edd6b
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: settings/django/settings.py
   match: SECRET_KEY = "9XJcj90y!X%KvLh#cG!&$ra(L(isX-ee8wqr18wr)(s9k^3G%k"
   secret: 9XJcj90y!X%KvLh#cG!&$ra(L(isX-ee8wqr18wr)(s9k^3G%k
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: settings/generic/config.ini
   match: Password = "cd7b820459d36b9339b78afb23b8c631"
   secret: cd7b820459d36b9339b78afb23b8c631
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: settings/generic/config.ini
   match: password = "cd7b820459d36b9339b78afb23b8c631"
   secret: cd7b820459d36b9339b78afb23b8c631
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: settings/generic/config.json
   match: 'Password": "cd7b820459d36b9339b78afb23b8c631"'
   secret: cd7b820459d36b9339b78afb23b8c631
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: settings/generic/config.json
   match: 'password": "cd7b820459d36b9339b78afb23b8c631"'
   secret: cd7b820459d36b9339b78afb23b8c631
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: settings/generic/config.json
   match: 'secret": "cd7b820459d36b9339b78afb23b8c631"'
   secret: cd7b820459d36b9339b78afb23b8c631
 
 - rule.description: Generic Secret
-  rule.id: a8d78f8de4bad0b519a8a14b625bc6d8ae3055bd8d8de6fc5c4b0b31bac4249e
+  rule.id: eCOHX_SKGzA
   location.path: settings/generic/config.xml
   match: <password>cd7b820459d36b9339b78afb23b8c631</password>
   secret: cd7b820459d36b9339b78afb23b8c631
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: settings/generic/file with spaces
   match: password="5MkjTjmfxnYgEdcLAB+dJPlqvdVEf9GCS9bseM+kegnhTjDridJU2cGQfy8jfP5nKxx2tmAGCRA+8EeGAw4QOg=="
   secret: 5MkjTjmfxnYgEdcLAB+dJPlqvdVEf9GCS9bseM+kegnhTjDridJU2cGQfy8jfP5nKxx2tmAGCRA+8EeGAw4QOg==
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: settings/generic/file with spaces
   match: secret="XdnBsJWJ9yS6bG10hXa5+KkGCr1HKMv5g"
   secret: XdnBsJWJ9yS6bG10hXa5+KkGCr1HKMv5g
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: settings/generic/file with spaces
   match: secret_key="5MkjTjmfxnYgEdcLAB+dJPlqvdVEf9GCS9bseM+kegnhTjDridJU2cGQfy8jfP5nKxx2tmAGCRA+8EeGAw4QOg=="
   secret: 5MkjTjmfxnYgEdcLAB+dJPlqvdVEf9GCS9bseM+kegnhTjDridJU2cGQfy8jfP5nKxx2tmAGCRA+8EeGAw4QOg==
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: settings/generic/secret
   match: password="5MkjTjmfxnYgEdcLAB+dJPlqvdVEf9GCS9bseM+kegnhTjDridJU2cGQfy8jfP5nKxx2tmAGCRA+8EeGAw4QOg=="
   secret: 5MkjTjmfxnYgEdcLAB+dJPlqvdVEf9GCS9bseM+kegnhTjDridJU2cGQfy8jfP5nKxx2tmAGCRA+8EeGAw4QOg==
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: settings/generic/secret
   match: secret="XdnBsJWJ9yS6bG10hXa5+KkGCr1HKMv5g"
   secret: XdnBsJWJ9yS6bG10hXa5+KkGCr1HKMv5g
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: settings/generic/secret
   match: secret_key="5MkjTjmfxnYgEdcLAB+dJPlqvdVEf9GCS9bseM+kegnhTjDridJU2cGQfy8jfP5nKxx2tmAGCRA+8EeGAw4QOg=="
   secret: 5MkjTjmfxnYgEdcLAB+dJPlqvdVEf9GCS9bseM+kegnhTjDridJU2cGQfy8jfP5nKxx2tmAGCRA+8EeGAw4QOg==
 
 - rule.description: Generic Secret
-  rule.id: 08147f6d4edc040aa8cc8d9313221aad0f0826de534f250b9987e6357bf8ae44
+  rule.id: mC5kOxQ6kn4
   location.path: some.secret
   match: BMlZufZmtbiUX3CX3_d1NxhUWIH_cT6_nQ4J-rJRW6Q
   secret: BMlZufZmtbiUX3CX3_d1NxhUWIH_cT6_nQ4J-rJRW6Q
 
 - rule.description: Generic Secret
-  rule.id: cdcf75b34688c4e0d60fa7a6e76fb4ca38f979b3278c4bfed23ebb1366790e22
+  rule.id: _-9w6-yrc-4
   location.path: src/azure-cli/azure/cli/command_modules/aro/tests/latest/recordings/foo.yml
   match: secret='/GNvEGXEXY9BS/YNvE:${asdf.YNvEGXEXY9BS}'
   secret: /GNvEGXEXY9BS/YNvE:${asdf.YNvEGXEXY9BS}
 
 - rule.description: Generic Secret
-  rule.id: dd85b788ea6c12f4968c38091c2576ff17ce23565d8d14f2a3b34d44dccddec2
+  rule.id: rnWF160pWNg
   location.path: yaml-test.yaml
   match: 'Secret: /GNvEGgEXY9BS/YNvEasdf.YNvEGXEXY9BS}'
   secret: /GNvEGgEXY9BS/YNvEasdf.YNvEGXEXY9BS}
 
 - rule.description: Generic Secret
-  rule.id: dd85b788ea6c12f4968c38091c2576ff17ce23565d8d14f2a3b34d44dccddec2
+  rule.id: rnWF160pWNg
   location.path: yaml-test.yaml
   match: 'secret: /XNvEGXEXY9B9/YNvEasdf.YNvEGXEXY9BS}'
   secret: /XNvEGXEXY9B9/YNvEasdf.YNvEGXEXY9BS}
 
 - rule.description: Generic Secret
-  rule.id: dd85b788ea6c12f4968c38091c2576ff17ce23565d8d14f2a3b34d44dccddec2
+  rule.id: rnWF160pWNg
   location.path: yaml-test.yaml
   match: 'secretKey: /GNvEGXEXm9BS/YNvE:asdf.YNvEGXEXY9BS}'
   secret: /GNvEGXEXm9BS/YNvE:asdf.YNvEGXEXY9BS}
 
 - rule.description: Generic Secret
-  rule.id: dd85b788ea6c12f4968c38091c2576ff17ce23565d8d14f2a3b34d44dccddec2
+  rule.id: rnWF160pWNg
   location.path: yaml-test.yml
   match: 'Token: /ANvEGX1XY9BS/YNvE:asdf.YNvEGXEXY9BS}'
   secret: /ANvEGX1XY9BS/YNvE:asdf.YNvEGXEXY9BS}
 
 - rule.description: Generic Secret
-  rule.id: dd85b788ea6c12f4968c38091c2576ff17ce23565d8d14f2a3b34d44dccddec2
+  rule.id: rnWF160pWNg
   location.path: yaml-test.yml
   match: 'secret-key: /GNvEGXElY9BS/YNvE:asdf.YNvEGXEXY9BS}'
   secret: /GNvEGXElY9BS/YNvE:asdf.YNvEGXEXY9BS}
 
 - rule.description: Generic Secret
-  rule.id: dd85b788ea6c12f4968c38091c2576ff17ce23565d8d14f2a3b34d44dccddec2
+  rule.id: rnWF160pWNg
   location.path: yaml-test.yml
   match: 'secret: /LNvEGXEXY9Bx/YNvE{asdf.YNvEGXEXY9BS}'
   secret: /LNvEGXEXY9Bx/YNvE{asdf.YNvEGXEXY9BS}
@@ -1063,7 +1063,7 @@
 #
 
 - rule.description: GitHub Fine-Grained Personal Access Token
-  rule.id: f71af8c158940a1539bfb08feaa24e36bf584c9c819002ea989c6aa35319d2db
+  rule.id: kX_PwM0MFvE
   location.path: github/valid/fine-grained-personal-access-token
   match: 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
   secret: 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
@@ -1073,7 +1073,7 @@
 #
 
 - rule.description: GitHub OAuth Access Token
-  rule.id: 0e347181fa64a66c62628972058788e0caf23a3c6a5be7822a01f29b65a6a9f0
+  rule.id: 3J1l0v_MrA0
   location.path: github/valid/oauth-access-token
   match: gho_16C7e42F292c6912E7710c838347Ae178B4a
   secret: gho_16C7e42F292c6912E7710c838347Ae178B4a
@@ -1083,25 +1083,25 @@
 #
 
 - rule.description: GitHub Personal Access Token
-  rule.id: a4ec986531bed1c154627c941eda6a95ef016481574cdfcb34249b648eb85ec7
+  rule.id: gODCNuGzuKQ
   location.path: github/valid/personal-access-token-env-var
   match: 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
   secret: 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
 
 - rule.description: GitHub Personal Access Token
-  rule.id: a4ec986531bed1c154627c941eda6a95ef016481574cdfcb34249b648eb85ec7
+  rule.id: gODCNuGzuKQ
   location.path: github/valid/personal-access-token-env-var
   match: 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
   secret: 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
 
 - rule.description: GitHub Personal Access Token
-  rule.id: a4ec986531bed1c154627c941eda6a95ef016481574cdfcb34249b648eb85ec7
+  rule.id: gODCNuGzuKQ
   location.path: github/valid/personal-access-token-in-url
   match: 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
   secret: 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
 
 - rule.description: GitHub Personal Access Token
-  rule.id: a4ec986531bed1c154627c941eda6a95ef016481574cdfcb34249b648eb85ec7
+  rule.id: gODCNuGzuKQ
   location.path: github/valid/personal-access-token-in-xml
   match: ghp_16C7e42F292c6912E7710c838347Ae178B4a
   secret: ghp_16C7e42F292c6912E7710c838347Ae178B4a
@@ -1111,7 +1111,7 @@
 #
 
 - rule.description: GitHub Refresh Token
-  rule.id: 86141b0de6dfc25b4ff6fe7c74c9283367a1d1c9c2d4df99ad9b8948e5d462db
+  rule.id: ReSYq_S3Ou0
   location.path: github/valid/refresh-token
   match: ghr_16C7e42F292c6912E7710c838347Ae178B4a
   secret: ghr_16C7e42F292c6912E7710c838347Ae178B4a
@@ -1121,7 +1121,7 @@
 #
 
 - rule.description: GitHub Server to Server Token
-  rule.id: 357286368ed645f842a99b4b1bf585181a6edf2e466287fa97fa8e887729e614
+  rule.id: YmXj5Lk-jw4
   location.path: github/valid/server-to-server-token
   match: ghs_16C7e42F292c6912E7710c838347Ae178B4a
   secret: ghs_16C7e42F292c6912E7710c838347Ae178B4a
@@ -1131,7 +1131,7 @@
 #
 
 - rule.description: GitHub User to Server Token
-  rule.id: afe1c727a3b8fb95f9b4e08ff05d501c5faab40e3c621ebc95468bae6dfb7d1b
+  rule.id: MMuUwURWAhM
   location.path: github/valid/user-to-server-token
   match: ghu_16C7e42F292c6912E7710c838347Ae178B4a
   secret: ghu_16C7e42F292c6912E7710c838347Ae178B4a
@@ -1141,7 +1141,7 @@
 #
 
 - rule.description: GitLab Access Token
-  rule.id: 0f6a47c693ad7a56c4a835f6aa7b38d18c343becae2f833fac2db51ecebd79e2
+  rule.id: KJX2Vbp6_jY
   location.path: general-test
   match: glpat-LwnfdsSHX1aSGxsqsPUX
   secret: glpat-LwnfdsSHX1aSGxsqsPUX
@@ -1151,7 +1151,7 @@
 #
 
 - rule.description: GitLab Pipeline Trigger Token
-  rule.id: 798acef3dc3135b6c9482635a042cb405e3c050631ef0e3ccc3556dddc9254d1
+  rule.id: IOimnsNGyvw
   location.path: general-test
   match: glptt-bcce2270d3c9c90c0a4320b6e8742fb450c27cc9
   secret: glptt-bcce2270d3c9c90c0a4320b6e8742fb450c27cc9
@@ -1161,13 +1161,13 @@
 #
 
 - rule.description: GitLab Runner Registration Token
-  rule.id: 7561d77130281f0e7b2339650a591ca94bf46c41dd9ca8cfe137fd4a1953d1b8
+  rule.id: 5eH7BIYmpNo
   location.path: general-test
   match: GR134894164NXmvdxFL_9cliRha7y
   secret: GR134894164NXmvdxFL_9cliRha7y
 
 - rule.description: GitLab Runner Registration Token
-  rule.id: 7561d77130281f0e7b2339650a591ca94bf46c41dd9ca8cfe137fd4a1953d1b8
+  rule.id: 5eH7BIYmpNo
   location.path: general-test
   match: glrt-64NXmvdxFL_9cliRha7y
   secret: glrt-64NXmvdxFL_9cliRha7y
@@ -1177,25 +1177,25 @@
 #
 
 - rule.description: Google Cloud Platform API Key
-  rule.id: 051eedb0bcb561306cadb6f5d310147c71edc1965d29b07ab38df8c54a623aba
+  rule.id: HysINeDft8k
   location.path: general-test
   match: AIzaOObST8cGSeh3cYNvEGXEXY9BShQx1EtRdfZ
   secret: AIzaOObST8cGSeh3cYNvEGXEXY9BShQx1EtRdfZ
 
 - rule.description: Google Cloud Platform API Key
-  rule.id: 051eedb0bcb561306cadb6f5d310147c71edc1965d29b07ab38df8c54a623aba
+  rule.id: HysINeDft8k
   location.path: semgrep-rules-examples/detected-google-api-key.txt
   match: AIzaSyBGJlWlxZEnJ2yUape3AjqmNyo5xxh6xtI
   secret: AIzaSyBGJlWlxZEnJ2yUape3AjqmNyo5xxh6xtI
 
 - rule.description: Google Cloud Platform API Key
-  rule.id: 051eedb0bcb561306cadb6f5d310147c71edc1965d29b07ab38df8c54a623aba
+  rule.id: HysINeDft8k
   location.path: semgrep-rules-examples/detected-google-cloud-api-key.txt
   match: AIzaSyCqhkgrLTLSOFyLyoS5gfN47TJ0HnHA_XA
   secret: AIzaSyCqhkgrLTLSOFyLyoS5gfN47TJ0HnHA_XA
 
 - rule.description: Google Cloud Platform API Key
-  rule.id: 051eedb0bcb561306cadb6f5d310147c71edc1965d29b07ab38df8c54a623aba
+  rule.id: HysINeDft8k
   location.path: semgrep-rules-examples/detected-google-cloud-api-key.txt
   match: AIzaSyCqhkgr\TLSOFyLyoS5gfN47TJ0HnHA_XA
   secret: AIzaSyCqhkgr\TLSOFyLyoS5gfN47TJ0HnHA_XA
@@ -1205,7 +1205,7 @@
 #
 
 - rule.description: Groq API Key
-  rule.id: 33dc3d2c2470b17d9a29bd1f66d650f36dfab0e01ada76b8d7e254cd5da93ed9
+  rule.id: F8ySDDFvEPA
   location.path: groq
   match: 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
   secret: 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
@@ -1215,14 +1215,14 @@
 #
 
 - rule.description: HashiCorp Vault AppRole SecretID
-  rule.id: a4618135ef6270cf16be1c2aca72038a86e781645fa2df8e4d8165848bb7e943
+  rule.id: rZUmm0ozLWQ
   location.path: hashicorp-vault/valid/ansible-vault-lookup-via-app-role
   match: vault.vault_read', 'auth/approle/role/role-name/role-id', url='https://vault:8201',
     secret_id='dd3cf500-f9f9-4052-a768-1f22ac57d107
   secret: dd3cf500-f9f9-4052-a768-1f22ac57d107
 
 - rule.description: HashiCorp Vault AppRole SecretID
-  rule.id: a4618135ef6270cf16be1c2aca72038a86e781645fa2df8e4d8165848bb7e943
+  rule.id: rZUmm0ozLWQ
   location.path: hashicorp-vault/valid/multiline-ansible-vault-lookup-via-app-role
   match: |-
     vault.vault_read',
@@ -1232,7 +1232,7 @@
   secret: dd3cf500-f9f9-4052-a768-1f22ac57d107
 
 - rule.description: HashiCorp Vault AppRole SecretID
-  rule.id: a4618135ef6270cf16be1c2aca72038a86e781645fa2df8e4d8165848bb7e943
+  rule.id: rZUmm0ozLWQ
   location.path: hashicorp-vault/valid/multiline-vault-cli-approle-login
   match: |-
     vault write auth/approle/login \
@@ -1241,7 +1241,7 @@
   secret: 6a174c20-f6de-a53c-74d2-6018fcceff64
 
 - rule.description: HashiCorp Vault AppRole SecretID
-  rule.id: a4618135ef6270cf16be1c2aca72038a86e781645fa2df8e4d8165848bb7e943
+  rule.id: rZUmm0ozLWQ
   location.path: hashicorp-vault/valid/vault-cli-approle-login
   match: vault write auth/approle/login role_id=db02de05-fa39-4855-059b-67221c5c2f63
     secret_id=6a174c20-f6de-a53c-74d2-6018fcceff64
@@ -1252,19 +1252,19 @@
 #
 
 - rule.description: Heroku API Token
-  rule.id: 25a1be50e7c5c93b6f7d468adaadd6ff0f62dea6f60af64c9415f5b6ccbee8ce
+  rule.id: 6Tfk9iWtINY
   location.path: heroku
   match: heroku_token = "cf0e05d9-4eca-4948-a012-b91fe9704bab
   secret: cf0e05d9-4eca-4948-a012-b91fe9704bab
 
 - rule.description: Heroku API Token
-  rule.id: 25a1be50e7c5c93b6f7d468adaadd6ff0f62dea6f60af64c9415f5b6ccbee8ce
+  rule.id: 6Tfk9iWtINY
   location.path: semgrep-rules-examples/detected-heroku-api-key.txt
   match: HEROKU_API_KEY = A6264401-E60A-48A9-941F-6446E78EC164
   secret: A6264401-E60A-48A9-941F-6446E78EC164
 
 - rule.description: Heroku API Token
-  rule.id: 25a1be50e7c5c93b6f7d468adaadd6ff0f62dea6f60af64c9415f5b6ccbee8ce
+  rule.id: 6Tfk9iWtINY
   location.path: semgrep-rules-examples/detected-heroku-api-key.txt
   match: heroku_api_key = a6264401-e60a-48a9-941f-6446e78ec164
   secret: a6264401-e60a-48a9-941f-6446e78ec164
@@ -1274,7 +1274,7 @@
 #
 
 - rule.description: Htpasswd File
-  rule.id: 365926758922192ee27da4b29bc2cb6ee7b3af1bbf75cfd479283b57c909a58f
+  rule.id: 8nWBN4ZoGf8
   location.path: htpasswd/valid/simple.htpasswd
   match: bob123:$apr1$FaPYZHMz$jYiw5.ExmVKeLbjex5Jvr34uA/
   secret: $apr1$FaPYZHMz$jYiw5.ExmVKeLbjex5Jvr34uA/
@@ -1284,7 +1284,7 @@
 #
 
 - rule.description: Hugging Face API Token
-  rule.id: 35dfcd9a65eaa32f3ba685014cdfc0963b411b48853263df5a5582bb3620d0fe
+  rule.id: ROB1tToGkqM
   location.path: huggingface-api-keys
   match: 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
   secret: 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
@@ -1294,19 +1294,19 @@
 #
 
 - rule.description: Kubernetes System Service Account JWT
-  rule.id: 50ed3470a6a293dd257ba4786f2e08da9e6eec64442c606f81859150f29e9b49
+  rule.id: vAAom0bPHy8
   location.path: k8s/valid/ad-hoc-service-account-token
   match: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6Zm9vIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.68gxpqTqhOhCGxXPe3D86xblMnRc2ciGYn-SMG78IDE
   secret: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6Zm9vIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.68gxpqTqhOhCGxXPe3D86xblMnRc2ciGYn-SMG78IDE
 
 - rule.description: Kubernetes System Service Account JWT
-  rule.id: 50ed3470a6a293dd257ba4786f2e08da9e6eec64442c606f81859150f29e9b49
+  rule.id: vAAom0bPHy8
   location.path: k8s/valid/double-encoded-service-account-token
   match: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6Zm9vIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.68gxpqTqhOhCGxXPe3D86xblMnRc2ciGYn-SMG78IDE
   secret: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6Zm9vIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.68gxpqTqhOhCGxXPe3D86xblMnRc2ciGYn-SMG78IDE
 
 - rule.description: Kubernetes System Service Account JWT
-  rule.id: 50ed3470a6a293dd257ba4786f2e08da9e6eec64442c606f81859150f29e9b49
+  rule.id: vAAom0bPHy8
   location.path: k8s/valid/prometheus-k8s-service-account-token
   match: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6b3BlbnNoaWZ0LW1vbml0b3Jpbmc6cHJvbWV0aGV1cy1rOHMiLCJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE1MTYyMzkwMjJ9.ipzDwTMDecOi1y3PCnr18juUFF9KryIreesxYUlC3AI
   secret: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6b3BlbnNoaWZ0LW1vbml0b3Jpbmc6cHJvbWV0aGV1cy1rOHMiLCJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE1MTYyMzkwMjJ9.ipzDwTMDecOi1y3PCnr18juUFF9KryIreesxYUlC3AI
@@ -1316,19 +1316,19 @@
 #
 
 - rule.description: MailChimp API Key
-  rule.id: 0dc120e36dbbe5eec937807366ca120ce22e0ee28543f6e08fcb09039fb1b8dc
+  rule.id: Evwi072oSOU
   location.path: mailchimp
   match: ae54fcc23ade65fa404a65e78c56f898-us1
   secret: ae54fcc23ade65fa404a65e78c56f898-us1
 
 - rule.description: MailChimp API Key
-  rule.id: 0dc120e36dbbe5eec937807366ca120ce22e0ee28543f6e08fcb09039fb1b8dc
+  rule.id: Evwi072oSOU
   location.path: mailchimp
   match: ae54fcc23ade65fa404a65e78c56f898-us1
   secret: ae54fcc23ade65fa404a65e78c56f898-us1
 
 - rule.description: MailChimp API Key
-  rule.id: 0dc120e36dbbe5eec937807366ca120ce22e0ee28543f6e08fcb09039fb1b8dc
+  rule.id: Evwi072oSOU
   location.path: semgrep-rules-examples/detected-mailchimp-api-key.txt
   match: ac954d9304919994498d92eb0c1669b0-us8
   secret: ac954d9304919994498d92eb0c1669b0-us8
@@ -1338,7 +1338,7 @@
 #
 
 - rule.description: Mailgun API Key
-  rule.id: 3bbe47102af6d87aaba1814062eae73dc0a840adcec38451a6cb5689d74a6961
+  rule.id: 0Fj-HDkaBWM
   location.path: general-test
   match: Mailgun_API_KEY=key-fb959af04c12d5d66091256c2b2076d0
   secret: key-fb959af04c12d5d66091256c2b2076d0
@@ -1348,13 +1348,13 @@
 #
 
 - rule.description: NPM Access Token
-  rule.id: c23ef58e849f9272eddd95bb6f9ea503341d4b7f6f043088b227252e8ebefe8b
+  rule.id: tBcMT24UjGQ
   location.path: npm/valid/access-token-assigned-to-a-vairable
   match: npm_1Uad0raLM5saR4HOZsEpRxar6x2Kji2ULDcl
   secret: npm_1Uad0raLM5saR4HOZsEpRxar6x2Kji2ULDcl
 
 - rule.description: NPM Access Token
-  rule.id: c23ef58e849f9272eddd95bb6f9ea503341d4b7f6f043088b227252e8ebefe8b
+  rule.id: tBcMT24UjGQ
   location.path: npm/valid/access-token-by-itself
   match: npm_0Uad0raLM5saR4HOZsEpRxar6x2Kji2ULDcl
   secret: npm_0Uad0raLM5saR4HOZsEpRxar6x2Kji2ULDcl
@@ -1364,7 +1364,7 @@
 #
 
 - rule.description: NPM Registry Auth
-  rule.id: fd46ccfd70fb3b77859e535635c0fe3cb51c7d5be6f23f9cc40c5d0d226f59a1
+  rule.id: tSFtnbvWdlk
   location.path: npm/valid/registry-auth-in-npmrc/.npmrc
   match: _authToken=6bM3d5xWYGcmXM01Ht77f4ga8xESVerk13uuS
   secret: 6bM3d5xWYGcmXM01Ht77f4ga8xESVerk13uuS
@@ -1374,37 +1374,37 @@
 #
 
 - rule.description: OpenAI API Key
-  rule.id: 0e0e2ecf6a3b0b450004b49f0b7b7a1a3e67c07ff0465cc4363ade5d4ee43a76
+  rule.id: LSd2f7avYkQ
   location.path: openai-api-keys
   match: sk-dFGv9W8ddVx2ExKBQRz_A8kIUzDywgeihqekfHe-ZQT3BlbkFJEPaGpGqyt-Nd2oVBq0eCrHEydWuEayXwDakgVKwdvW
   secret: sk-dFGv9W8ddVx2ExKBQRz_A8kIUzDywgeihqekfHe-ZQT3BlbkFJEPaGpGqyt-Nd2oVBq0eCrHEydWuEayXwDakgVKwdvW
 
 - rule.description: OpenAI API Key
-  rule.id: 0e0e2ecf6a3b0b450004b49f0b7b7a1a3e67c07ff0465cc4363ade5d4ee43a76
+  rule.id: LSd2f7avYkQ
   location.path: openai-api-keys
   match: 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
   secret: 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
 
 - rule.description: OpenAI API Key
-  rule.id: 0e0e2ecf6a3b0b450004b49f0b7b7a1a3e67c07ff0465cc4363ade5d4ee43a76
+  rule.id: LSd2f7avYkQ
   location.path: openai-api-keys
   match: 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
   secret: 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
 
 - rule.description: OpenAI API Key
-  rule.id: 0e0e2ecf6a3b0b450004b49f0b7b7a1a3e67c07ff0465cc4363ade5d4ee43a76
+  rule.id: LSd2f7avYkQ
   location.path: openai-api-keys
   match: sk-svcacct-hqCUiUfGXirUladeUfMjreBlRCyHi4XPt66HaQTYNCsy9dRHNT3BlbkFJBNz-ihgm_vbebhKnpaOjpGZUVGN81gwBZ2iOAZZpDFW0syp6rG
   secret: sk-svcacct-hqCUiUfGXirUladeUfMjreBlRCyHi4XPt66HaQTYNCsy9dRHNT3BlbkFJBNz-ihgm_vbebhKnpaOjpGZUVGN81gwBZ2iOAZZpDFW0syp6rG
 
 - rule.description: OpenAI API Key
-  rule.id: 0e0e2ecf6a3b0b450004b49f0b7b7a1a3e67c07ff0465cc4363ade5d4ee43a76
+  rule.id: LSd2f7avYkQ
   location.path: openai-api-keys
   match: sk-svcacct-p3HN0fGfBSZtU1SZLNURBJKtDfjwGP-biXNehD8xtUdKwT3BlbkFJHcjP031AuuZ_lTN0zZ_U3PEO6d-jaAP-brKmmvK-ihvnQA
   secret: sk-svcacct-p3HN0fGfBSZtU1SZLNURBJKtDfjwGP-biXNehD8xtUdKwT3BlbkFJHcjP031AuuZ_lTN0zZ_U3PEO6d-jaAP-brKmmvK-ihvnQA
 
 - rule.description: OpenAI API Key
-  rule.id: 0e0e2ecf6a3b0b450004b49f0b7b7a1a3e67c07ff0465cc4363ade5d4ee43a76
+  rule.id: LSd2f7avYkQ
   location.path: openai-api-keys
   match: sk-xN93diMvdzhoYXQ6n_CovPMMxJPuE5UHH90n8QC4SAT3BlbkFJP1ZIyIyMyfhguXzRU0E-jomb9uozZO4O9uUGaXFCl4
   secret: sk-xN93diMvdzhoYXQ6n_CovPMMxJPuE5UHH90n8QC4SAT3BlbkFJP1ZIyIyMyfhguXzRU0E-jomb9uozZO4O9uUGaXFCl4
@@ -1414,7 +1414,7 @@
 #
 
 - rule.description: OpenShift Login Token
-  rule.id: 7c288b0becc8b6186eb504a34fc56ea0102837ee0aaa1e573c4c82fa7aec808c
+  rule.id: DaAdIBwZoGE
   location.path: general-test
   match: oc login --some-opt --token=sha256~CL9vOGM0koa67eipnogHwP6KmfeAOd6ZwMo88Qo3-Kw
   secret: sha256~CL9vOGM0koa67eipnogHwP6KmfeAOd6ZwMo88Qo3-Kw
@@ -1424,7 +1424,7 @@
 #
 
 - rule.description: 'PKCS #12 File'
-  rule.id: f77b54d43771f272fb0b6e385431dfac83c3170c3105f353db7db4f3dcaa9587
+  rule.id: RA8jFaMQxIg
   location.path: foo.p12
   match: 'file detected: foo.p12'
   secret: ''
@@ -1434,55 +1434,55 @@
 #
 
 - rule.description: Password Hash
-  rule.id: b9a128e8a1782a7670b73aac71f5a909d64c3e570ee700baddd8aa4afa0e7589
+  rule.id: iGgJnI-f5Xk
   location.path: password-hash/valid/SunMD5
   match: $md5,rounds=89650$IU7ELX9N$$VUWQHUYZkb7n3SpAmBHq0/
   secret: $md5,rounds=89650$IU7ELX9N$$VUWQHUYZkb7n3SpAmBHq0/
 
 - rule.description: Password Hash
-  rule.id: a0e89d6e0593122ed5f0fcf19b54f480b63767b925a4c844f1da27dbf5462013
+  rule.id: RX7HEzTc6dI
   location.path: password-hash/valid/bcrypt
   match: $2b$05$YuHSRtnwiF7AbEd3Xe9rauK0N8EHKHoajjAPQz/29QMGdbisxy.3.
   secret: $2b$05$YuHSRtnwiF7AbEd3Xe9rauK0N8EHKHoajjAPQz/29QMGdbisxy.3.
 
 - rule.description: Password Hash
-  rule.id: d843e3b5ee1a726c2570c8fb14e26509d699d8bb1aa2426b9c5ec6127670abac
+  rule.id: fqtWnpN0lfA
   location.path: password-hash/valid/gost-yescrypt
   match: $gy$j9T$7Q9Z.KDwQ06akx6VxwMpn.$en8X0EUE.xdbTSDZlftyzqDEcXaU7rORvdWLhaPygB2
   secret: $gy$j9T$7Q9Z.KDwQ06akx6VxwMpn.$en8X0EUE.xdbTSDZlftyzqDEcXaU7rORvdWLhaPygB2
 
 - rule.description: Password Hash
-  rule.id: 65af234cecb9abc2f22a3cf70a11c3ebf952a95a70a33d79da9875e7158ff077
+  rule.id: AeVJW2sPHGs
   location.path: password-hash/valid/md5crypt
   match: $1$lMsBjmBR$3UpSfv5QTMtGoneFKCIJW1
   secret: $1$lMsBjmBR$3UpSfv5QTMtGoneFKCIJW1
 
 - rule.description: Password Hash
-  rule.id: b402738f45253e5ebae94f8ed3d8ed5c8499ff6e2a5709ed7aae0e4e33116f3e
+  rule.id: u9MfgjhX7SI
   location.path: password-hash/valid/sha256crypt
   match: $5$8pFTUnUr.HhP3O52$Fl1S4nX1p0PONBIcG7PN5jTQAtulYNf2AQCJyXV6Dt.
   secret: $5$8pFTUnUr.HhP3O52$Fl1S4nX1p0PONBIcG7PN5jTQAtulYNf2AQCJyXV6Dt.
 
 - rule.description: Password Hash
-  rule.id: a83ee4469a916041850c68b13b9d21dc85bfebc28b69b2f97273b61d5ba760fe
+  rule.id: amXYPF5An5s
   location.path: password-hash/valid/sha512crypt
   match: $6$cjvUY6xnMEVNYUv6$ttG2bz2lglfS4rliP.T7Ozaak7bPVg5ccZ.E.H5F09jIOfvG/yJb5nfQ3tN6uMiH7Z1t/AXDHUgD5xdqE6MUu1
   secret: $6$cjvUY6xnMEVNYUv6$ttG2bz2lglfS4rliP.T7Ozaak7bPVg5ccZ.E.H5F09jIOfvG/yJb5nfQ3tN6uMiH7Z1t/AXDHUgD5xdqE6MUu1
 
 - rule.description: Password Hash
-  rule.id: 0f75ca0dd1fd85ed8160b8a693107cdf3904edf31d0985edf84fabf7500f2c2c
+  rule.id: bYudTkTa56I
   location.path: password-hash/valid/yescrypt
   match: $y$j9T$OO/cvWZ17nxP6XzO1jNt5/$wtUrYmUAzg6p1hdQ/WJtsjq7gJ6if4dP6LcDlXedZU6
   secret: $y$j9T$OO/cvWZ17nxP6XzO1jNt5/$wtUrYmUAzg6p1hdQ/WJtsjq7gJ6if4dP6LcDlXedZU6
 
 - rule.description: Password Hash
-  rule.id: a0e89d6e0593122ed5f0fcf19b54f480b63767b925a4c844f1da27dbf5462013
+  rule.id: RX7HEzTc6dI
   location.path: semgrep-rules-examples/detected-bcrypt-hash.txt
   match: $2y$12$s.YfVZdfvAuO/Iz6fte5iO..ZbbEgreZnDcYOGvX4NGJskYQIstcG
   secret: $2y$12$s.YfVZdfvAuO/Iz6fte5iO..ZbbEgreZnDcYOGvX4NGJskYQIstcG
 
 - rule.description: Password Hash
-  rule.id: a83ee4469a916041850c68b13b9d21dc85bfebc28b69b2f97273b61d5ba760fe
+  rule.id: amXYPF5An5s
   location.path: semgrep-rules-examples/detected-etc-shadow.txt
   match: $6$LnUhhUi45srUKt9i$4Hp6VRTOB2mxvsYH8mwsCfBryg6hCbm4JJjV26KplN8ewZ7EUVqQDkLKDW.O8XRHx.B76JkwXtyD3wnAXEuZN1
   secret: $6$LnUhhUi45srUKt9i$4Hp6VRTOB2mxvsYH8mwsCfBryg6hCbm4JJjV26KplN8ewZ7EUVqQDkLKDW.O8XRHx.B76JkwXtyD3wnAXEuZN1
@@ -1492,7 +1492,7 @@
 #
 
 - rule.description: PayPal Braintree Access Token
-  rule.id: 18f3e8e86fa5995e6c64c1479f82019d34e4c076967cdfc1f759db0c783c4498
+  rule.id: NSjjvv0VeYg
   location.path: semgrep-rules-examples/detected-paypal-braintree-access-token.txt
   match: access_token$production$aaa722wk737379q3$afefae5aa65de111123a72251111e065
   secret: access_token$production$aaa722wk737379q3$afefae5aa65de111123a72251111e065
@@ -1502,7 +1502,7 @@
 #
 
 - rule.description: Picatic API Key
-  rule.id: a84e30dd04b2e829ba75f341f16fb1f4bb2371f8e82e8442b14c594bbad482cb
+  rule.id: K3ZNQj2_kTE
   location.path: picatic
   match: sk_live_f304d35aebd75fb1d648d7a2517cd367
   secret: sk_live_f304d35aebd75fb1d648d7a2517cd367
@@ -1512,7 +1512,7 @@
 #
 
 - rule.description: Private Key
-  rule.id: d5929654009ea640795908a2dcdb07f2f0ebbef42d1ac472bace4b4cd458ce98
+  rule.id: ePK9whPQPpY
   location.path: gcp-credentials.json
   match: '-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCrZWq5zTKn2nSm\npwv3sAyYPSSjCtHoqEPnKCey7Yt/gjvA6R2EadmwrepDVo08DC1wMHoILH8skRqb\nly3CGB2T/b2G7sVN5OUFlQ2Gc8DRIVgUFMdWhNTk0zYSkDTaqro1e78pYHoLBmjI\ntcQhDtb8aPFamJHGLb+Mc2p/qQaT7F5F4ASOiIvdvqvuijAINvHxeTKIpEs0oNy6\n8msKbumv77y4AQswxdFwECUfCDRsUbD18/LR0Md5KvHGNkuyjFn+3lrWrxNBt7gj\nXZeMM9SJ14ovYgXRj6B0JCVUty1gUY4+xqlGarEJtq4I+VCO5piYNTCHYYZWKmhI\nqLKZGyRTAgMBAAECggEAOmts/zuj4nahgBQ8DgahpFpi3HfZqFWCH44eSeyRubpo\nJ47Nks6JdqEw0hb0ON1lt3Guho60IjqrORFEdX3GxySbrxw/gBdewJJXc9aMiDu3\nS9DxSNopvn0HVzhz63x5z7UIKVBLCOr8WD0sRqBKQup6KYkLVuNNANBuImk4Zr6A\nl2hXN6Oc/zjjTAVVOYhISe8Zuk7ojHeoRoUHj8u0XGqTzFHOKxYSB6I6bbrRm12B\nZYClbNElB6JtJm6OSlRQ2HEgTbyyGKp6bIHijPF2x2EaOLMmeCvC2ic70zvZ+3F3\nSqJKz0C1hYk1yzTsnHF/YNOiSIlYuepNt0gZbRVRsQKBgQDpif2P423/Yb7BlFYN\nCOihbWbtrP1DLzz9Fl3trBp4X+REXu2t2b0gZxGR/e8dO0u5G3TiGuAa112GkpSa\nSiXoE+DiHQaFDuVbP6zMDImDGYc7/h0BeZTVtoKW9vm5QaLw/h5ltKKzJp+NI/Nd\nDstJ+5YrmipW/aL3GRDeBzVIBQKBgQC74WUYjP/cpqf8cv8bbG+8GkbmBPiSrMD9\nzenvzS6lEONJsbysYgKa1Bc8jwikJqaEpKHqt+tQC//tPkUngedh+rykxMlPljjC\ncHE/Nxk76BkYJeKg4EklTQtP2zvkfBEeVxQQ2fax7Oo2Opm45lTLQA5mix6lPB5g\n3weDpY4idwKBgFjG1PXqvbjUHmCWE/QWi+A5p2P4W7o7bdLDuucLgnB5+1smPvHU\nkLmNlLdLsacKEGoIjvEYyFJLxkjO1eClCS3kyJsL75uLIxMB7J0QswF8JdVfbwVN\ng4+ONqxOrHWJBvjXkRSWizbRGtvba7rXUd4I3ngqvaed+WI3TBsq4E1FAoGATVHu\nRBNK/SjM+3TsDgIrXbNGuEUVc2+LISiL/PdpGd+AWoS+DAdt4QAl6/NFcCDD6NTE\nGg/E1LWLhrxYw3CPo+AHoJun6Yv+Ie8afBSV2vSi1zBIO0Lyd1pkrGGiHV79wIm/\npUu+Xe0NWnH1b4XDIb5j7smUPBYovl8q/X+1pfMCgYEAiisg+/l/cO80VvcZpeJ3\nZBCJ/N4xf/PU8cN5MsvSGDXiU8ylripGre78javrsInM38oZVxGyjR7BDKdpkWpi\nk8D0zAMwopOraNKuhFw+YDwbELPEc9AZABP+hgn709lJgM4KUD+7Fq7YxpeTAgYM\nN5o0tJt10SKwOXow4jLP8Fs=\n-----END
     PRIVATE KEY-----'
@@ -1520,7 +1520,7 @@
     PRIVATE KEY-----'
 
 - rule.description: Private Key
-  rule.id: d5929654009ea640795908a2dcdb07f2f0ebbef42d1ac472bace4b4cd458ce98
+  rule.id: ePK9whPQPpY
   location.path: pki/valid/b64-encoded-openssh-private-key
   match: |-
     -----BEGIN OPENSSH PRIVATE KEY-----
@@ -1542,7 +1542,7 @@
     -----END OPENSSH PRIVATE KEY-----
 
 - rule.description: Private Key
-  rule.id: d5929654009ea640795908a2dcdb07f2f0ebbef42d1ac472bace4b4cd458ce98
+  rule.id: ePK9whPQPpY
   location.path: pki/valid/inline-openssh-key
   match: '-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAACmFlczI1Ni1jdHIAAAAGYmNyeXB0AAAAGAAAABBLJRcyw4\nUacchG66A5xxhzAAAAGAAAAAEAAAAzAAAAC3NzaC1lZDI1NTE5AAAAIB8CSDIKG8VNj2+O\nR6bChx99Rfev7Jnnw5mVcoSZD9/qAAAAoDasFmlcpXIXig64bM6DFGPM3iAO4fKPAD/bgp\njmqZ2vKBLKcDghsZ9EI5C1amSkv6/yv6HscHC1jvo6RJrFJFpKa4UNU0cypMolXLrcQAqo\ndMSgh8nmvK1neWv8VvB89yxIgKLevn8WxyVnj3rgTVcDO8b2ypn8f/lkgb3/ka8nRMVbAo\nfg1lDLLDjYNdoYK6gY5TA3zuLVQBhSHSGKNLE=\n-----END
     OPENSSH PRIVATE KEY-----'
@@ -1550,7 +1550,7 @@
     OPENSSH PRIVATE KEY-----'
 
 - rule.description: Private Key
-  rule.id: d5929654009ea640795908a2dcdb07f2f0ebbef42d1ac472bace4b4cd458ce98
+  rule.id: ePK9whPQPpY
   location.path: pki/valid/inline-server.key
   match: '-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKXwggSjAgEAAoIBAQDW8OVrrcJ/rZxZ\n/kHlgz5THtgGS2VTbCpMzhksfrD0eFnPAzxTSW/5oDk3iT9AfKnRDWnYYogIvb6e\nEoKCqHXLbDVPIdZlFi6wRmr82u8HJAZaqGmPklwag2ajNFBpct4LXpzY70gvWt1e\n6s+kTDqEv+jw60Cl6NizUtkPmBJSJYgVUsDH2zt4lQl4A0yMr82SBpRJjrlX6jrE\nt8PjrMHKESD02SUkah096D33UI8jhD+MYhvatkucDL2dffoD8ZHUj0wPYtj4jb0m\nNd50X5YKjKZtwezbWzZ78auknHJXkaLf9lYYJW78UeDotoJ5md8wbiTVyxCVHt6V\nUtnBfWHJAgMBAAECggEAZ7XYnPo8bOrSFEIwfZO0ENtDFNZwT65TQrf3QZbnvy4K\n923yP6Whl+sNcJSSpoUAU1SLi9MPHFihjxgTTQQHwl214zbKggAQCxIPMW5aAzII\nttmoBZRzSH+6mGj3m8nHBeli+PGL/P107wWRpw749XC77vM0QFl3ph8FiRaxUFzV\nM0CMcRRoGmAB+5lsOQlM38jJIs01HWLmfoKfUd9R+ciW0uda2nsTsopaRu0rlOP7\nCOJ28c/NrFbVL+Dgs6cmCQUe/MOGF4x9KNgRLam4LiUag8x0CBmvAkcwu/vtvSD7\nJY5UaTb0slwCyAJaVzVKG4dPPVte27AZGvZEUmycmQKBgQDxhDnZPp85IqJbnoj4\npkpc2m+cSQq8Ct6OXXiqQYZTAnMEY1SOZdhXDySjyr2hPQ0HItktdj9ulNGYickV\nBqBgZURq+st7cAPl0yFsAf1TGTDzmFT7EUeR7hI6VraCyz2p17On27EGtuWTdCOD\njcIm6eBjE+ArIdohSsOu51RTywKBgQDj1K5/elTisRJMOCtMtRTfkeYzimXG+XdY\nppPhAjEF5mioyfFpiizR+RbyvwMdSqUChU6UTVIpd02Gl1dN55LRnQ5KnbHY6xLg\n0WkL1Cv5NXsKHQxAbQL9O+k66IkY6IPljMH+JMnI12XRGzi+LQw/86Sc2irJBqp+\nvF9osnv2OwKBgQC1D5f+0f+0ac6mORgesSwWqHv8ApZVmyB2QoTvvufg23k21PDT\nQG8L9YJWeOvpMUfPDcUbXAb58/+eB84EQU+CdOjx+ssJ41RIvBvWSTeNUNluBcnP\n34h0UrK/obp6G7xC1D8PnJf+nKdIAE2PlnrziWp7XK82Js7NHqvNOAf0OQKBgDwy\nYbjE9dC/wHnrDWXDIrS/s/dCRgoAuAvwV3pIPfO1IUoXsXWVUKpaCjoxRf1jT54O\n4uhEVcUnBJDfQ+4NlblUqgYFDIyn7+D+86ZwdP3vp4bQjgAnzXZjcghikHbIWLE6\nM7eWuMocP4a0jpWRCX+MPJ5E9rEO1dWOqBbdsespAoGAGdsLb/RaHHk2KVLQvd3B\nECoKfVdoyiyiesMXa8UBZm+EuCnvKt0TkefLq2a7mj1S7tVzX4Qax19kpB4540FL\n9HnGt3Wj19PfHr6WSW7cVhXZ0QoCP4+1+VpuJJitQcfZhMTOn2sAx4lRR3po/zac\nbR6f0IOR8YEtSlJ1T/CLTm0=\n-----END
     PRIVATE KEY-----'
@@ -1558,7 +1558,7 @@
     PRIVATE KEY-----'
 
 - rule.description: Private Key
-  rule.id: d5929654009ea640795908a2dcdb07f2f0ebbef42d1ac472bace4b4cd458ce98
+  rule.id: ePK9whPQPpY
   location.path: pki/valid/private.key
   match: |-
     -----BEGIN PRIVATE KEY-----
@@ -1620,7 +1620,7 @@
     -----END PRIVATE KEY-----
 
 - rule.description: Private Key
-  rule.id: d5929654009ea640795908a2dcdb07f2f0ebbef42d1ac472bace4b4cd458ce98
+  rule.id: ePK9whPQPpY
   location.path: pki/valid/short-ec-private.key
   match: |-
     -----BEGIN EC PRIVATE KEY-----
@@ -1642,7 +1642,7 @@
 #
 
 - rule.description: PyPI Upload Token
-  rule.id: e28317dbb1b2104c7fca5911047d8315152fd6f230bd07d5188fc9e461154559
+  rule.id: ZeqrEVYyN7A
   location.path: general-test
   match: pypi-AgEIcHlwaS5vcmcCJDU0ZTIxMWRiLWNlMjYtNDM3ZS05YjJlLWYzYTk5NmE2NGJjMgACJXsicGVybWlzc2lvbnMiOiAidXNlciIsICJ2ZXJzaW9uIjogMX0AAAYgWzvnJ7sF-57Jw_YGg04aZTPCeuRpXrHBhAsPRfofZGc
   secret: pypi-AgEIcHlwaS5vcmcCJDU0ZTIxMWRiLWNlMjYtNDM3ZS05YjJlLWYzYTk5NmE2NGJjMgACJXsicGVybWlzc2lvbnMiOiAidXNlciIsICJ2ZXJzaW9uIjogMX0AAAYgWzvnJ7sF-57Jw_YGg04aZTPCeuRpXrHBhAsPRfofZGc
@@ -1652,67 +1652,67 @@
 #
 
 - rule.description: SendGrid API Key
-  rule.id: 76b4d3b89d4af399881204c7d8520e0c88a78f2662f31a3f674c51d4d64c8baa
+  rule.id: fJqKYcYx3bk
   location.path: semgrep-rules-examples/detected-sendgrid-api-key.txt
   match: SG.ngeVfQFYQlKU0ufo8x5d1.TwL2iGABf9DHoTf-09kqeF8tAmbihYzrnopKc-1s5cr
   secret: SG.ngeVfQFYQlKU0ufo8x5d1.TwL2iGABf9DHoTf-09kqeF8tAmbihYzrnopKc-1s5cr
 
 - rule.description: SendGrid API Key
-  rule.id: 76b4d3b89d4af399881204c7d8520e0c88a78f2662f31a3f674c51d4d64c8baa
+  rule.id: fJqKYcYx3bk
   location.path: semgrep-rules-examples/detected-sendgrid-api-key.txt
   match: SG.ngeVfQFYQlKU0ufo8x5d1A.TwL2iGABf9DHoTf-09kqeF8tAmbihYzrnopKc-1s5c
   secret: SG.ngeVfQFYQlKU0ufo8x5d1A.TwL2iGABf9DHoTf-09kqeF8tAmbihYzrnopKc-1s5c
 
 - rule.description: SendGrid API Key
-  rule.id: 76b4d3b89d4af399881204c7d8520e0c88a78f2662f31a3f674c51d4d64c8baa
+  rule.id: fJqKYcYx3bk
   location.path: semgrep-rules-examples/detected-sendgrid-api-key.txt
   match: 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
   secret: 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
 
 - rule.description: SendGrid API Key
-  rule.id: 76b4d3b89d4af399881204c7d8520e0c88a78f2662f31a3f674c51d4d64c8baa
+  rule.id: fJqKYcYx3bk
   location.path: semgrep-rules-examples/detected-sendgrid-api-key.txt
   match: SG.ngeVfQFYQlKU0ufo8x5d1A.TwL2iGABf9DHoTf-09kqeF8tAmbihYzrnopKc-1s5crt
   secret: SG.ngeVfQFYQlKU0ufo8x5d1A.TwL2iGABf9DHoTf-09kqeF8tAmbihYzrnopKc-1s5crt
 
 - rule.description: SendGrid API Key
-  rule.id: 76b4d3b89d4af399881204c7d8520e0c88a78f2662f31a3f674c51d4d64c8baa
+  rule.id: fJqKYcYx3bk
   location.path: semgrep-rules-examples/detected-sendgrid-api-key.txt
   match: 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
   secret: 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
 
 - rule.description: SendGrid API Key
-  rule.id: 76b4d3b89d4af399881204c7d8520e0c88a78f2662f31a3f674c51d4d64c8baa
+  rule.id: fJqKYcYx3bk
   location.path: sendgrid
   match: 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
   secret: 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
 
 - rule.description: SendGrid API Key
-  rule.id: 76b4d3b89d4af399881204c7d8520e0c88a78f2662f31a3f674c51d4d64c8baa
+  rule.id: fJqKYcYx3bk
   location.path: sendgrid
   match: SG.9C07-916Ee9X80Yd0b32M3f27922.9C07-916-e9XL0Yaaxad0b32M3f27922
   secret: SG.9C07-916Ee9X80Yd0b32M3f27922.9C07-916-e9XL0Yaaxad0b32M3f27922
 
 - rule.description: SendGrid API Key
-  rule.id: 76b4d3b89d4af399881204c7d8520e0c88a78f2662f31a3f674c51d4d64c8baa
+  rule.id: fJqKYcYx3bk
   location.path: sendgrid
   match: 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
   secret: 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
 
 - rule.description: SendGrid API Key
-  rule.id: 76b4d3b89d4af399881204c7d8520e0c88a78f2662f31a3f674c51d4d64c8baa
+  rule.id: fJqKYcYx3bk
   location.path: sendgrid
   match: SG.aCyFXhLSGTuJSe-XxTmYxw.ZWurK7hcHhqVmX6R9y3wZYImTDZVRuuvIZWurK7hcHh
   secret: SG.aCyFXhLSGTuJSe-XxTmYxw.ZWurK7hcHhqVmX6R9y3wZYImTDZVRuuvIZWurK7hcHh
 
 - rule.description: SendGrid API Key
-  rule.id: 76b4d3b89d4af399881204c7d8520e0c88a78f2662f31a3f674c51d4d64c8baa
+  rule.id: fJqKYcYx3bk
   location.path: sendgrid
   match: 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
   secret: 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
 
 - rule.description: SendGrid API Key
-  rule.id: 76b4d3b89d4af399881204c7d8520e0c88a78f2662f31a3f674c51d4d64c8baa
+  rule.id: fJqKYcYx3bk
   location.path: sendgrid
   match: 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
   secret: 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
@@ -1722,7 +1722,7 @@
 #
 
 - rule.description: Shopify Access Token
-  rule.id: 37a8264122df85941c43def588a1220665951ca17fcf91e8bccff786fc9f2ec7
+  rule.id: Rn1i7_84x3E
   location.path: shopify
   match: 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
   secret: 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
@@ -1732,7 +1732,7 @@
 #
 
 - rule.description: Shopify Custom App Access Token
-  rule.id: 96e0c0f3da0e818283af13398ad43b51ff5be7c2c38dd6ef3b3bafae181dafb9
+  rule.id: 2yT2HilWNWU
   location.path: shopify
   match: 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
   secret: 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
@@ -1742,7 +1742,7 @@
 #
 
 - rule.description: Shopify Private App Access Token
-  rule.id: 7d4c55c2eaad8ec04d6c035009f797144c1f04b661d1054fced4e48771a90512
+  rule.id: Q3_9607B5YA
   location.path: shopify
   match: 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
   secret: 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
@@ -1752,7 +1752,7 @@
 #
 
 - rule.description: Shopify Shared Secret
-  rule.id: b840bb3f6dccc679a425bfa5573540fe3bacbed4d48f166dcfc496235025a40a
+  rule.id: xgtaj9NNvtQ
   location.path: shopify
   match: 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
   secret: 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
@@ -1762,7 +1762,7 @@
 #
 
 - rule.description: Slack App Token
-  rule.id: 2f2bd1d768b6950cc2c4d84b0368c07fc423872e403bb4774a75e1d7072704d2
+  rule.id: PdsUpd2VsLw
   location.path: slack
   match: xapp-1-IEMF8IMY1OQ-4037076220459-85c370b433e366de369c4ef5abdf41253519266982439a75af74a3d68d543fb6
   secret: xapp-1-IEMF8IMY1OQ-4037076220459-85c370b433e366de369c4ef5abdf41253519266982439a75af74a3d68d543fb6
@@ -1772,7 +1772,7 @@
 #
 
 - rule.description: Slack Bot Token
-  rule.id: e94a2be853d40c0833ab7d9efa7e4c3987350be8044d82c2630de95b1aa512f2
+  rule.id: AHqBipAQalU
   location.path: semgrep-rules-examples/detected-slack-token.txt
   match: xoxb-244636495000-244564491300-Wwpw98abcdabcdefabcdabcz
   secret: xoxb-244636495000-244564491300-Wwpw98abcdabcdefabcdabcz
@@ -1782,7 +1782,7 @@
 #
 
 - rule.description: Slack User Token
-  rule.id: 71ecced1b8ebb3c4fd316f5ef68c0208703e7fd757b3548808dca2f585de5275
+  rule.id: 6mKbEmEYQDY
   location.path: semgrep-rules-examples/detected-slack-token.txt
   match: xoxp-825568119270-820571134562-983439002315-b3358323912928aeeeeeeeeeeeeeeezz
   secret: xoxp-825568119270-820571134562-983439002315-b3358323912928aeeeeeeeeeeeeeeezz
@@ -1792,13 +1792,13 @@
 #
 
 - rule.description: Slack Webhook URL
-  rule.id: df8c74800f04ca32c33c1b94100e03a70ae0941c78c97ed556e71121781c91f6
+  rule.id: CPcj1txuB2g
   location.path: semgrep-rules-examples/detected-slack-webhook.txt
   match: https://hooks.slack.com/services/T12345678/B12345678/abcd1234efgh5678ijkl90zy
   secret: https://hooks.slack.com/services/T12345678/B12345678/abcd1234efgh5678ijkl90zy
 
 - rule.description: Slack Webhook URL
-  rule.id: df8c74800f04ca32c33c1b94100e03a70ae0941c78c97ed556e71121781c91f6
+  rule.id: CPcj1txuB2g
   location.path: semgrep-rules-examples/detected-slack-webhook.txt
   match: https://hooks.slack.com/services/T12345678/B1234567890/abcd1234efgh5678ijkl90zy
   secret: https://hooks.slack.com/services/T12345678/B1234567890/abcd1234efgh5678ijkl90zy
@@ -1808,7 +1808,7 @@
 #
 
 - rule.description: Snowflake OAuth Token
-  rule.id: 538346458f04daa723c81812eb5f5a84198efbba46e6aa01f4341d8bf325dac6
+  rule.id: pcwMvzsYJ5U
   location.path: snowflake
   match: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3MjYyNDU1OTUsImlhdCI6MTcyNjI0NTU5NSwianRpIjoiZjExODIzZTItNGUzZS00ZTE1LTg5NjEtNzI4NzVkOTgzY2Q3IiwiaXNzIjoiaHR0cHM6Ly9pZHAuaW50ZXJuYWwiLCJhdWQiOiJzbm93Zmxha2VfZXhhbXBsZSIsInN1YiI6IjNkYTlmYjQ2LWYxY2EtNDkwOS1iNzM1LWJkNWRjNjQzNDRkOCIsInR5cCI6IkJlYXJlciIsImF6cCI6ImNsaWVudCIsInNjb3BlIjoic2Vzc2lvbjpyb2xlLWFueSJ9.Kv1x-VxlJwPzf6WNjgz6WDu8OxVutdkIVNgfDXcxN7Q
   secret: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3MjYyNDU1OTUsImlhdCI6MTcyNjI0NTU5NSwianRpIjoiZjExODIzZTItNGUzZS00ZTE1LTg5NjEtNzI4NzVkOTgzY2Q3IiwiaXNzIjoiaHR0cHM6Ly9pZHAuaW50ZXJuYWwiLCJhdWQiOiJzbm93Zmxha2VfZXhhbXBsZSIsInN1YiI6IjNkYTlmYjQ2LWYxY2EtNDkwOS1iNzM1LWJkNWRjNjQzNDRkOCIsInR5cCI6IkJlYXJlciIsImF6cCI6ImNsaWVudCIsInNjb3BlIjoic2Vzc2lvbjpyb2xlLWFueSJ9.Kv1x-VxlJwPzf6WNjgz6WDu8OxVutdkIVNgfDXcxN7Q
@@ -1818,7 +1818,7 @@
 #
 
 - rule.description: Square Access Token
-  rule.id: 7ff01b130235b65837366618698b00f6ae038c42f40ea2ef5ed3dd084b0703c6
+  rule.id: fZHzd4gAHrs
   location.path: semgrep-rules-examples/detected-square-access-token.txt
   match: sq0atp-KoblahBLAHBLAHbEHA6yuw
   secret: sq0atp-KoblahBLAHBLAHbEHA6yuw
@@ -1828,7 +1828,7 @@
 #
 
 - rule.description: StackRox JWT
-  rule.id: d4d9fc7b1e757e23c3bee62914079b1e1df294fafa025814db41be41d3312520
+  rule.id: FrTqjJHAoEY
   location.path: stackrox/valid/api-token
   match: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJodHRwczovL3N0YWNrcm94LmlvL2p3dC1zb3VyY2VzI2FwaS10b2tlbnMiLCJleHAiOjE3MjkxMTIxMjUsImlhdCI6MTcyOTExMjEyNSwiaXNzIjoiaHR0cHM6Ly9zdGFja3JveC5pby9qd3QiLCJqdGkiOiI5OTQ5N2I3Yy1mMjllLTRkNGUtYWE1ZS0yYzM0N2E1Y2U0MjAiLCJuYW1lIjoicm94X2FwaV90b2tlbiIsInJvbGVzIjpbIkNvbnRpbnVvdXMgSW50ZWdyYXRpb24iXX0.zFbfszkOPuH8eJ8vjxrsLAHVBS6jg7V8V3ZEpOhkLRA
   secret: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJodHRwczovL3N0YWNrcm94LmlvL2p3dC1zb3VyY2VzI2FwaS10b2tlbnMiLCJleHAiOjE3MjkxMTIxMjUsImlhdCI6MTcyOTExMjEyNSwiaXNzIjoiaHR0cHM6Ly9zdGFja3JveC5pby9qd3QiLCJqdGkiOiI5OTQ5N2I3Yy1mMjllLTRkNGUtYWE1ZS0yYzM0N2E1Y2U0MjAiLCJuYW1lIjoicm94X2FwaV90b2tlbiIsInJvbGVzIjpbIkNvbnRpbnVvdXMgSW50ZWdyYXRpb24iXX0.zFbfszkOPuH8eJ8vjxrsLAHVBS6jg7V8V3ZEpOhkLRA
@@ -1838,13 +1838,13 @@
 #
 
 - rule.description: Stripe API Key
-  rule.id: 08786b3a6732a572e87937bee1a7b033c9d8a47893a1a5c488ae57a2b1edc191
+  rule.id: CSHGj8J1lUs
   location.path: semgrep-rules-examples/detected-stripe-api-key.txt
   match: sk_live_xf2fh0Hu3LqXlqqUg2DEWhEz
   secret: sk_live_xf2fh0Hu3LqXlqqUg2DEWhEz
 
 - rule.description: Stripe API Key
-  rule.id: 08786b3a6732a572e87937bee1a7b033c9d8a47893a1a5c488ae57a2b1edc191
+  rule.id: CSHGj8J1lUs
   location.path: semgrep-rules-examples/detected-stripe-restricted-api-key.txt
   match: rk_live_xf2fh0Hu3LqXlqqUg2DEWhEz
   secret: rk_live_xf2fh0Hu3LqXlqqUg2DEWhEz
@@ -1854,25 +1854,25 @@
 #
 
 - rule.description: Testing Farm API Token
-  rule.id: 2fd47406ee312ed2fe6a9331f2d8759dca28f427cc71cba16e547e52c04ed60c
+  rule.id: lSFsU9hapFQ
   location.path: testing-farm
   match: TESTING_FARM_API_TOKEN="20f83e10-d568-41af-b350-de8675ab1d08
   secret: 20f83e10-d568-41af-b350-de8675ab1d08
 
 - rule.description: Testing Farm API Token
-  rule.id: 2fd47406ee312ed2fe6a9331f2d8759dca28f427cc71cba16e547e52c04ed60c
+  rule.id: lSFsU9hapFQ
   location.path: testing-farm
   match: TESTING_FARM_API_TOKEN='30f83e10-d568-41af-b350-de8675ab1d08
   secret: 30f83e10-d568-41af-b350-de8675ab1d08
 
 - rule.description: Testing Farm API Token
-  rule.id: 2fd47406ee312ed2fe6a9331f2d8759dca28f427cc71cba16e547e52c04ed60c
+  rule.id: lSFsU9hapFQ
   location.path: testing-farm
   match: TESTING_FARM_API_TOKEN=00f83e10-d568-41af-b350-de8675ab1d08
   secret: 00f83e10-d568-41af-b350-de8675ab1d08
 
 - rule.description: Testing Farm API Token
-  rule.id: 2fd47406ee312ed2fe6a9331f2d8759dca28f427cc71cba16e547e52c04ed60c
+  rule.id: lSFsU9hapFQ
   location.path: testing-farm
   match: TESTING_FARM_API_TOKEN=10f83e10-d568-41af-b350-de8675ab1d08
   secret: 10f83e10-d568-41af-b350-de8675ab1d08
@@ -1882,7 +1882,7 @@
 #
 
 - rule.description: Tines Webhook
-  rule.id: 44e5461c5358d708f9b9387d50c976907320173c36e6a68d52b61152d76d5da7
+  rule.id: TiwMt5e05g4
   location.path: tines/valid/webhook-url
   match: https://goofy-cat-1984.tines.com/webhook/019cd913e7056ad466a9af156a8244cd/4f4980a83eb96af5085f6cfcdafe6bd0
   secret: https://goofy-cat-1984.tines.com/webhook/019cd913e7056ad466a9af156a8244cd/4f4980a83eb96af5085f6cfcdafe6bd0
@@ -1892,7 +1892,7 @@
 #
 
 - rule.description: Twilio API Key
-  rule.id: 5fd1363bdb194ec6981ebff1be9f2b5591c10f5f6acb7dbaf129b48df83d707e
+  rule.id: hRAjGfP0Zao
   location.path: semgrep-rules-examples/detected-twilio-api-key.txt
   match: SK575796bb721246b5fe003bcc32ebde77
   secret: SK575796bb721246b5fe003bcc32ebde77
@@ -1902,43 +1902,43 @@
 #
 
 - rule.description: URL User and Password
-  rule.id: 76475708ab8cf6060eb30ea8cb33e964d89860c3c4eb57dd64d583cf835be84e
+  rule.id: NoSStdj9pfY
   location.path: general-test
   match: http://username:1d902de68e4113f5855a6c88314cec6a@foo.bar.leaktk.org
   secret: 1d902de68e4113f5855a6c88314cec6a
 
 - rule.description: URL User and Password
-  rule.id: 76475708ab8cf6060eb30ea8cb33e964d89860c3c4eb57dd64d583cf835be84e
+  rule.id: NoSStdj9pfY
   location.path: general-test
   match: https://username:2d902de68e4113f5855a6c88314cec6a@foo.bar.leaktk.org
   secret: 2d902de68e4113f5855a6c88314cec6a
 
 - rule.description: URL User and Password
-  rule.id: 76475708ab8cf6060eb30ea8cb33e964d89860c3c4eb57dd64d583cf835be84e
+  rule.id: NoSStdj9pfY
   location.path: general-test
   match: rsync://username:9d902de68e4113f5855a6c88314cec6a@foo.bar.leaktk.org
   secret: 9d902de68e4113f5855a6c88314cec6a
 
 - rule.description: URL User and Password
-  rule.id: 76475708ab8cf6060eb30ea8cb33e964d89860c3c4eb57dd64d583cf835be84e
+  rule.id: NoSStdj9pfY
   location.path: github/valid/personal-access-token-in-url
   match: https://phaticusthiccy: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@github.com
   secret: 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
 
 - rule.description: URL User and Password
-  rule.id: 76475708ab8cf6060eb30ea8cb33e964d89860c3c4eb57dd64d583cf835be84e
+  rule.id: NoSStdj9pfY
   location.path: k8s/valid/secret-stringdata-after-quotes-single.yaml
   match: mongodb://gm6vx_gtfs:zCGp9*ghPmt#ezFjdrqo6nyI@mongo-gtfs-mongodb
   secret: zCGp9*ghPmt#ezFjdrqo6nyI
 
 - rule.description: URL User and Password
-  rule.id: 76475708ab8cf6060eb30ea8cb33e964d89860c3c4eb57dd64d583cf835be84e
+  rule.id: NoSStdj9pfY
   location.path: k8s/valid/secret-stringdata-before-quotes-single.yaml
   match: mongodb://gm6vx_gtfs:zCGp9*ghPmt#ezFjdrqo6nyI@mongo-gtfs-mongodb
   secret: zCGp9*ghPmt#ezFjdrqo6nyI
 
 - rule.description: URL User and Password
-  rule.id: 76475708ab8cf6060eb30ea8cb33e964d89860c3c4eb57dd64d583cf835be84e
+  rule.id: NoSStdj9pfY
   location.path: semgrep-rules-examples/detected-username-and-password-in-uri.txt
   match: https://{get_user_name}:pwdTest123+@github.com
   secret: pwdTest123+
@@ -1948,111 +1948,111 @@
 #
 
 - rule.description: WP-Config
-  rule.id: 2ed9686c92f697123e4a9e031c14544486247659900fe2806078110a5c0cf695
+  rule.id: FxXgdaIgf7Y
   location.path: general-test
   match: define(    'DB_PASSWORD', '$c8e$743df9d386d895}')
   secret: $c8e$743df9d386d895}
 
 - rule.description: WP-Config
-  rule.id: 2ed9686c92f697123e4a9e031c14544486247659900fe2806078110a5c0cf695
+  rule.id: FxXgdaIgf7Y
   location.path: general-test
   match: define('AUTH_KEY',         'kzgllO;k$F_-W68 Fl*iEekX;-pn =fNS(;c9nDKt;5RW(&jtESXsW9+PhQFS!Tv')
   secret: kzgllO;k$F_-W68 Fl*iEekX;-pn =fNS(;c9nDKt;5RW(&jtESXsW9+PhQFS!Tv
 
 - rule.description: WP-Config
-  rule.id: 2ed9686c92f697123e4a9e031c14544486247659900fe2806078110a5c0cf695
+  rule.id: FxXgdaIgf7Y
   location.path: general-test
   match: define('AUTH_SALT',        '?PULIL7?y%Ub=[~rw+5Pg^!$UrrOpn*Pr(MFBdF-+ZMH#oKsZ{KskZY9m/i|<pkK')
   secret: ?PULIL7?y%Ub=[~rw+5Pg^!$UrrOpn*Pr(MFBdF-+ZMH#oKsZ{KskZY9m/i|<pkK
 
 - rule.description: WP-Config
-  rule.id: 2ed9686c92f697123e4a9e031c14544486247659900fe2806078110a5c0cf695
+  rule.id: FxXgdaIgf7Y
   location.path: general-test
   match: define('LOGGED_IN_KEY',    'k7o7@~oee{u,MG KFBJq0M`-iJ0H0hs)m-@i/RsgwZ{No~JQ+)2A<Ryd+|t<8.[a')
   secret: k7o7@~oee{u,MG KFBJq0M`-iJ0H0hs)m-@i/RsgwZ{No~JQ+)2A<Ryd+|t<8.[a
 
 - rule.description: WP-Config
-  rule.id: 2ed9686c92f697123e4a9e031c14544486247659900fe2806078110a5c0cf695
+  rule.id: FxXgdaIgf7Y
   location.path: general-test
   match: define('LOGGED_IN_SALT',   'WTc*{p+XT((_#^NxhoU)[7NAg};Q?`+0wpkia>oA]hF-TB2lC
     GM!~aM=-Hqw4,+')
   secret: WTc*{p+XT((_#^NxhoU)[7NAg};Q?`+0wpkia>oA]hF-TB2lC GM!~aM=-Hqw4,+
 
 - rule.description: WP-Config
-  rule.id: 2ed9686c92f697123e4a9e031c14544486247659900fe2806078110a5c0cf695
+  rule.id: FxXgdaIgf7Y
   location.path: general-test
   match: define('NONCE_KEY',        'f54j6Auj0NT8g;5-^zk}yZ`vN^8/7!6=%5bS>GUu{04~#E*a~WdGX<%>Aa<Ke}K8')
   secret: f54j6Auj0NT8g;5-^zk}yZ`vN^8/7!6=%5bS>GUu{04~#E*a~WdGX<%>Aa<Ke}K8
 
 - rule.description: WP-Config
-  rule.id: 2ed9686c92f697123e4a9e031c14544486247659900fe2806078110a5c0cf695
+  rule.id: FxXgdaIgf7Y
   location.path: general-test
   match: define('NONCE_SALT',       '^[_9^w_,UPMuJ2-}7=y<|v=y$#xftY[klEW3zt,Y}bB tG4d):p9Fd;$imF[lGqR')
   secret: ^[_9^w_,UPMuJ2-}7=y<|v=y$#xftY[klEW3zt,Y}bB tG4d):p9Fd;$imF[lGqR
 
 - rule.description: WP-Config
-  rule.id: 2ed9686c92f697123e4a9e031c14544486247659900fe2806078110a5c0cf695
+  rule.id: FxXgdaIgf7Y
   location.path: general-test
   match: define('SECURE_AUTH_KEY',  ',,F|NHKh>=+y.gy%B32Ff!s~MJp$L,]~xEK|e3H)7| 4hX]!/Ky@V(esZa?0D#H*')
   secret: ',,F|NHKh>=+y.gy%B32Ff!s~MJp$L,]~xEK|e3H)7| 4hX]!/Ky@V(esZa?0D#H*'
 
 - rule.description: WP-Config
-  rule.id: 2ed9686c92f697123e4a9e031c14544486247659900fe2806078110a5c0cf695
+  rule.id: FxXgdaIgf7Y
   location.path: general-test
   match: define('SECURE_AUTH_SALT', 'of~0;WuAmEBP4~rfM)1Q.Oc0U=g^t|d%h.Ui8w<v4;A47FGs0}@Hk>&g?p*hDoQs')
   secret: of~0;WuAmEBP4~rfM)1Q.Oc0U=g^t|d%h.Ui8w<v4;A47FGs0}@Hk>&g?p*hDoQs
 
 - rule.description: WP-Config
-  rule.id: 2ed9686c92f697123e4a9e031c14544486247659900fe2806078110a5c0cf695
+  rule.id: FxXgdaIgf7Y
   location.path: settings/wordpress/wp-config.php
   match: define( 'DB_PASSWORD', '9b2f7xfe6ebb88c0ae0f2a2f4ca66c42' )
   secret: 9b2f7xfe6ebb88c0ae0f2a2f4ca66c42
 
 - rule.description: WP-Config
-  rule.id: 2ed9686c92f697123e4a9e031c14544486247659900fe2806078110a5c0cf695
+  rule.id: FxXgdaIgf7Y
   location.path: settings/wordpress/wp-config.php
   match: define('AUTH_KEY',         'kzglvO;k$F_-W68 Fl*iEekX;-pn =fNS(;c6nDKt;5RW(&jtESBsW9+PhQFS!Tv')
   secret: kzglvO;k$F_-W68 Fl*iEekX;-pn =fNS(;c6nDKt;5RW(&jtESBsW9+PhQFS!Tv
 
 - rule.description: WP-Config
-  rule.id: 2ed9686c92f697123e4a9e031c14544486247659900fe2806078110a5c0cf695
+  rule.id: FxXgdaIgf7Y
   location.path: settings/wordpress/wp-config.php
   match: define('AUTH_SALT',        '?PULIL7?y%Ub=[~rw+5Pg^!$UrrOpn*Pr(MFBdF-+ZMH#oKsZ{KskZY9m/i|<pkK')
   secret: ?PULIL7?y%Ub=[~rw+5Pg^!$UrrOpn*Pr(MFBdF-+ZMH#oKsZ{KskZY9m/i|<pkK
 
 - rule.description: WP-Config
-  rule.id: 2ed9686c92f697123e4a9e031c14544486247659900fe2806078110a5c0cf695
+  rule.id: FxXgdaIgf7Y
   location.path: settings/wordpress/wp-config.php
   match: define('LOGGED_IN_KEY',    'k7o7@~oee{u,MG KFBJq0M`-iJ0H0hs)m-@i/RsgwZ{No~JQ+)2A<Ryd+|t<8.[a')
   secret: k7o7@~oee{u,MG KFBJq0M`-iJ0H0hs)m-@i/RsgwZ{No~JQ+)2A<Ryd+|t<8.[a
 
 - rule.description: WP-Config
-  rule.id: 2ed9686c92f697123e4a9e031c14544486247659900fe2806078110a5c0cf695
+  rule.id: FxXgdaIgf7Y
   location.path: settings/wordpress/wp-config.php
   match: define('LOGGED_IN_SALT',   'WTc*{p+XT((_#^NxhoU)[7NAg};Q?`+0wpkia>oA]hF-TB2lC
     GM!~aM=-Hqw4,+')
   secret: WTc*{p+XT((_#^NxhoU)[7NAg};Q?`+0wpkia>oA]hF-TB2lC GM!~aM=-Hqw4,+
 
 - rule.description: WP-Config
-  rule.id: 2ed9686c92f697123e4a9e031c14544486247659900fe2806078110a5c0cf695
+  rule.id: FxXgdaIgf7Y
   location.path: settings/wordpress/wp-config.php
   match: define('NONCE_KEY',        'f54j6Auj0NT8g;5-^zk}yZ`vN^8/7!6=%5bS>GUu{04~#E*a~WdGX<%>Aa<Ke}K8')
   secret: f54j6Auj0NT8g;5-^zk}yZ`vN^8/7!6=%5bS>GUu{04~#E*a~WdGX<%>Aa<Ke}K8
 
 - rule.description: WP-Config
-  rule.id: 2ed9686c92f697123e4a9e031c14544486247659900fe2806078110a5c0cf695
+  rule.id: FxXgdaIgf7Y
   location.path: settings/wordpress/wp-config.php
   match: define('NONCE_SALT',       '^[_9^w_,UPMuJ2-}7=y<|v=y$#xftY[klEW3zt,Y}bB tG4d):p9Fd;$imF[lGqR')
   secret: ^[_9^w_,UPMuJ2-}7=y<|v=y$#xftY[klEW3zt,Y}bB tG4d):p9Fd;$imF[lGqR
 
 - rule.description: WP-Config
-  rule.id: 2ed9686c92f697123e4a9e031c14544486247659900fe2806078110a5c0cf695
+  rule.id: FxXgdaIgf7Y
   location.path: settings/wordpress/wp-config.php
   match: define('SECURE_AUTH_KEY',  ',,F|NHKh>=+y.gy%B32Ff!s~MJp$L,]~xEK|e3H)7| 4hX]!/Ky@V(esZa?0D#H*')
   secret: ',,F|NHKh>=+y.gy%B32Ff!s~MJp$L,]~xEK|e3H)7| 4hX]!/Ky@V(esZa?0D#H*'
 
 - rule.description: WP-Config
-  rule.id: 2ed9686c92f697123e4a9e031c14544486247659900fe2806078110a5c0cf695
+  rule.id: FxXgdaIgf7Y
   location.path: settings/wordpress/wp-config.php
   match: define('SECURE_AUTH_SALT', 'of~0;WuAmEBP4~rfM)1Q.Oc0U=g^t|d%h.Ui8w<v4;A47FGs0}@Hk>&g?p*hDoQs')
   secret: of~0;WuAmEBP4~rfM)1Q.Oc0U=g^t|d%h.Ui8w<v4;A47FGs0}@Hk>&g?p*hDoQs


### PR DESCRIPTION
See https://github.com/leaktk/scanner/pull/89


Script used to make the change:

```
for id in $(cat ids)
do
   new_id="$(openssl rand 8 | basenc --base64url | sed -s 's/=//g' | tr -d '\n')"
   sed -i "s/${id}/${new_id}/g" $(rg "${id}" -l)
done
```

The `ids` file was using:

```
rg "id\s*[:=]\s*[\'\"]?([a-z0-9]{64})" -o -r '$1' --no-line-number --no-filename | sort -u > ids
```