### PR TITLE
Remove 'alert:repo-owner' from Password Hash rules

### DIFF
--- a/patterns/gitleaks/8.18.2/98-general.toml
+++ b/patterns/gitleaks/8.18.2/98-general.toml
@@ -922,7 +922,7 @@
   id = 'bYudTkTa56I'
   description = 'Password Hash'
   regex = '''\$y\$[.\/A-Za-z0-9]+\$[.\/A-Za-z0-9]{0,86}\$[.\/A-Za-z0-9]{43}'''
-  tags = ['type:secret', 'alert:repo-owner']
+  tags = ['type:secret']
   keywords = [
     '$y$',
   ]
@@ -943,7 +943,7 @@
   id = 'fqtWnpN0lfA'
   description = 'Password Hash'
   regex = '''\$gy\$[.\/A-Za-z0-9]+\$[.\/A-Za-z0-9]{0,86}\$[.\/A-Za-z0-9]{43}'''
-  tags = ['type:secret', 'alert:repo-owner']
+  tags = ['type:secret']
   keywords = [
     '$gy$',
   ]
@@ -964,7 +964,7 @@
   id = 'MxYvbqkT9IM'
   description = 'Password Hash'
   regex = '''\$7\$[.\/A-Za-z0-9]{11,97}\$[.\/A-Za-z0-9]{43}'''
-  tags = ['type:secret', 'alert:repo-owner']
+  tags = ['type:secret']
   keywords = [
     '$7$',
   ]
@@ -985,7 +985,7 @@
   id = 'RX7HEzTc6dI'
   description = 'Password Hash'
   regex = '''\$2[abxy]\$[0-9]{2}\$[.\/A-Za-z0-9]{53}'''
-  tags = ['type:secret', 'alert:repo-owner']
+  tags = ['type:secret']
   keywords = [
     '$2a$',
     '$2b$',
@@ -1009,7 +1009,7 @@
   id = 'amXYPF5An5s'
   description = 'Password Hash'
   regex = '''\$6\$(?:rounds=[1-9][0-9]+\$)?[^$:\n]{1,16}\$[.\/0-9A-Za-z]{86}'''
-  tags = ['type:secret', 'alert:repo-owner']
+  tags = ['type:secret']
   keywords = [
     '$6$',
   ]
@@ -1030,7 +1030,7 @@
   id = 'u9MfgjhX7SI'
   description = 'Password Hash'
   regex = '''\$5\$(?:rounds=[1-9][0-9]+\$)?[^$:\n]{1,16}\$[.\/0-9A-Za-z]{43}'''
-  tags = ['type:secret', 'alert:repo-owner']
+  tags = ['type:secret']
   keywords = [
     '$5$',
   ]
@@ -1051,7 +1051,7 @@
   id = 'iGgJnI-f5Xk'
   description = 'Password Hash'
   regex = '''\$md5(?:,rounds=[1-9][0-9]+)?\$[.\/0-9A-Za-z]{8}\${1,2}[.\/0-9A-Za-z]{22}'''
-  tags = ['type:secret', 'alert:repo-owner']
+  tags = ['type:secret']
   keywords = [
     '$md5',
   ]
@@ -1072,7 +1072,7 @@
   id = 'AeVJW2sPHGs'
   description = 'Password Hash'
   regex = '''\$1\$[^$:\n]{1,8}\$[.\/0-9A-Za-z]{22}'''
-  tags = ['type:secret', 'alert:repo-owner']
+  tags = ['type:secret']
   keywords = [
     '$1$',
   ]

--- a/target/patterns/gitleaks/8.18.2
+++ b/target/patterns/gitleaks/8.18.2
@@ -1001,7 +1001,7 @@ keywords = ["sha256~"]
 id = 'bYudTkTa56I'
 description = 'Password Hash'
 regex = '''\$y\$[.\/A-Za-z0-9]+\$[.\/A-Za-z0-9]{0,86}\$[.\/A-Za-z0-9]{43}'''
-tags = ['type:secret', 'alert:repo-owner']
+tags = ['type:secret']
 keywords = [
 '$y$',
 ]
@@ -1017,7 +1017,7 @@ regexes = [
 id = 'fqtWnpN0lfA'
 description = 'Password Hash'
 regex = '''\$gy\$[.\/A-Za-z0-9]+\$[.\/A-Za-z0-9]{0,86}\$[.\/A-Za-z0-9]{43}'''
-tags = ['type:secret', 'alert:repo-owner']
+tags = ['type:secret']
 keywords = [
 '$gy$',
 ]
@@ -1033,7 +1033,7 @@ regexes = [
 id = 'MxYvbqkT9IM'
 description = 'Password Hash'
 regex = '''\$7\$[.\/A-Za-z0-9]{11,97}\$[.\/A-Za-z0-9]{43}'''
-tags = ['type:secret', 'alert:repo-owner']
+tags = ['type:secret']
 keywords = [
 '$7$',
 ]
@@ -1049,7 +1049,7 @@ regexes = [
 id = 'RX7HEzTc6dI'
 description = 'Password Hash'
 regex = '''\$2[abxy]\$[0-9]{2}\$[.\/A-Za-z0-9]{53}'''
-tags = ['type:secret', 'alert:repo-owner']
+tags = ['type:secret']
 keywords = [
 '$2a$',
 '$2b$',
@@ -1068,7 +1068,7 @@ regexes = [
 id = 'amXYPF5An5s'
 description = 'Password Hash'
 regex = '''\$6\$(?:rounds=[1-9][0-9]+\$)?[^$:\n]{1,16}\$[.\/0-9A-Za-z]{86}'''
-tags = ['type:secret', 'alert:repo-owner']
+tags = ['type:secret']
 keywords = [
 '$6$',
 ]
@@ -1084,7 +1084,7 @@ regexes = [
 id = 'u9MfgjhX7SI'
 description = 'Password Hash'
 regex = '''\$5\$(?:rounds=[1-9][0-9]+\$)?[^$:\n]{1,16}\$[.\/0-9A-Za-z]{43}'''
-tags = ['type:secret', 'alert:repo-owner']
+tags = ['type:secret']
 keywords = [
 '$5$',
 ]
@@ -1100,7 +1100,7 @@ regexes = [
 id = 'iGgJnI-f5Xk'
 description = 'Password Hash'
 regex = '''\$md5(?:,rounds=[1-9][0-9]+)?\$[.\/0-9A-Za-z]{8}\${1,2}[.\/0-9A-Za-z]{22}'''
-tags = ['type:secret', 'alert:repo-owner']
+tags = ['type:secret']
 keywords = [
 '$md5',
 ]
@@ -1116,7 +1116,7 @@ regexes = [
 id = 'AeVJW2sPHGs'
 description = 'Password Hash'
 regex = '''\$1\$[^$:\n]{1,8}\$[.\/0-9A-Za-z]{22}'''
-tags = ['type:secret', 'alert:repo-owner']
+tags = ['type:secret']
 keywords = [
 '$1$',
 ]


### PR DESCRIPTION
In the scanner's current state these tend to be low risk, low-value alerts. Mostly test suites and such or low threat if truely a secret.